### PR TITLE
new version php sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,31 @@
 1. 注册开发者: BeeCloud平台[注册账号](http://beecloud.cn/register/)
 2. 创建应用: 使用注册的账号登陆,在控制台中创建应用,点击**"+添加应用"**创建新应用,具体可参考[快速开始](https://beecloud.cn/apply/)
 3. 获取参数: 在新创建的应用中即可获取APP ID,APP Secret,Master Secret,Test Secret
-4. 在SDK的sdk/src/rest/config.php代码中配置(请注意各个参数一一对应):
+4. 在代码中调用方法registerApp(请注意各个参数一一对应):
 
 ```
-const APP_ID = 'your app id';
-const APP_SECRET = 'your app secret';
-const TEST_SECRET = 'your test secret';
-const MASTER_SECRET = 'your master secret';
+/* registerApp fun four params
+ * @param(first) $app_id beecloud平台的APP ID
+ * @param(second) $app_secret  beecloud平台的APP SECRET
+ * @param(third) $master_secret  beecloud平台的MASTER SECRET
+ * @param(fouth) $test_secret  beecloud平台的TEST SECRET, for sandbox
+ */
+\beecloud\rest\api::registerApp('app id', 'app secret', 'master secret', 'test secret');
+//不使用namespace的用户和2.2.0之前的v2版本用户请使用
+BCRESTApi::registerApp('app id', 'app secret', 'master secret', 'test secret')
 ```
 
 5. LIVE模式和TEST模式
 
-在SDK的sdk/src/rest/config.php代码中设置参数TEST_MODE, 即:
-- TEST_MODE为false, 即LIVE模式
-- TEST_MODE为true, 即TEST模式, 仅提供下单和支付订单查询的Sandbox模式
+在代码中调用方法setMode, 即:
+- setMode(false)或者不调用此方法, 即LIVE模式
+- setMode(true), 即TEST模式, 仅提供下单和支付订单查询的Sandbox模式
 
 开启测试模式,即:
 ```
-define('TEST_MODE', true);
+\beecloud\rest\api::setMode(true);
+//不使用namespace的用户和2.2.0之前的v2版本用户请使用
+BCRESTApi::setMode(true)
 ```
 
 ## 引入BeeCloud API

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 BeeCloud PHP Changelog
 ========================================================
-v2.3.6 发布日期: 2016年7月5日
+v3.0.0 发布日期: 2016年7月5日
 + BeeCloud平台参数配置,原在sdk/src/rest/config.php设置常量,现更改为
   \beecloud\rest\api::registerApp('app id', 'app secret', 'master secret', 'test secret'),
   或者BCRESTApi::registerApp('app id', 'app secret', 'master secret', 'test secret')

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,22 @@
 BeeCloud PHP Changelog
 ========================================================
+v2.3.6 发布日期: 2016年7月5日
++ BeeCloud平台参数配置,原在sdk/src/rest/config.php设置常量,现更改为
+  \beecloud\rest\api::registerApp('app id', 'app secret', 'master secret', 'test secret'),
+  或者BCRESTApi::registerApp('app id', 'app secret', 'master secret', 'test secret')
+  (重点)
++ 原beecloud.php类BCRESTUtil中的方法request和sdk/src/rest/network.php中代码
+  curl_setopt($ch, CURLOPT_FAILONERROR, true)注释掉,以便获取返回http code大于400的结果
+  (重点)
++ Test Model,只提供下单和支付订单查询的Sandbox模式,不写setMode函数或者false即live模式,true即test模式
+  原在sdk/src/rest/config.php设置TEST_MODE常量,现更改为
+  \beecloud\rest\api::setMode(true),
+  或者BCRESTApi::setMode(true)
++ 原sdk/src/rest/config.php,更改为在类中定义各常量,以适用于采用composer包管理的用户
++ 修改READMD.md文件
+
+BeeCloud PHP Changelog
+========================================================
 v2.3.5 发布日期: 2016年6月24日
 + demo/wx/wx.jsapi.php中添加了对微信相关配置的描述
 + 支付渠道BC_EXPRESS添加银行卡号(card_no, 选填)字段的支持

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
             "email": "support@beecloud.cn"
         }
     ],
-    "version" : "v2.3.5",
+    "version" : "v3.0.0",
     "minimum-stability": "dev",
     "homepage": "https://beecloud.cn/",
     "require": {

--- a/demo/agree.refund.php
+++ b/demo/agree.refund.php
@@ -1,11 +1,10 @@
 <?php
 require_once("../loader.php");
+require_once("config.php");
 
-$data = array();
-$masterSecret = MASTER_SECRET;
-$data["app_id"] = APP_ID;
+//设置app id, app secret, master secret, test secret
+$api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
 $data["timestamp"] = time() * 1000;
-$data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $masterSecret);
 $data["bill_no"] = $_GET["bill_no"];
 $data["refund_no"] = $_GET["refund_no"];
 $data["refund_fee"] = (int)$_GET["refund_fee"];

--- a/demo/ali.offline.qrcode/ali.bill.cancel.php
+++ b/demo/ali.offline.qrcode/ali.bill.cancel.php
@@ -1,11 +1,11 @@
 <?php
 require_once("../../loader.php");
+require_once("../config.php");
 
-$data = array();
-$appSecret = APP_SECRET;
-$data["app_id"] = APP_ID;
+//设置app id, app secret, master secret, test secret
+$api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
+
 $data["timestamp"] = time() * 1000;
-$data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $appSecret);
 $data["channel"] = "ALI_OFFLINE_QRCODE";
 $data["bill_no"] = $_GET["billNo"];
 $data["method"] = "REVERT";

--- a/demo/ali.offline.qrcode/ali.bill.status.php
+++ b/demo/ali.offline.qrcode/ali.bill.status.php
@@ -1,11 +1,10 @@
 <?php
 require_once("../../loader.php");
+require_once("../config.php");
 
-$data = array();
-$appSecret = APP_SECRET;
-$data["app_id"] = APP_ID;
+//设置app id, app secret, master secret, test secret
+$api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
 $data["timestamp"] = time() * 1000;
-$data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $appSecret);
 $data["channel"] = "ALI_OFFLINE_QRCODE";
 $data["bill_no"] = $_GET["billNo"];
 try {

--- a/demo/ali.offline.qrcode/ali.qrcode.refund.php
+++ b/demo/ali.offline.qrcode/ali.qrcode.refund.php
@@ -8,12 +8,12 @@
 <table border="1" align="center" cellspacing=0>
 <?php
     require_once("../../loader.php");
+    require_once("../config.php");
 
-    $data = array();
-    $appSecret = APP_SECRET;
-    $data["app_id"] = APP_ID;
+    //设置app id, app secret, master secret, test secret
+    $api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
+
     $data["timestamp"] = time() * 1000;
-    $data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $appSecret);
     $data["bill_no"] = $_GET["bill_no"];
     $data["refund_no"] = $_GET["refund_no"];
     $data["refund_fee"] = (int)$_GET["refund_fee"];

--- a/demo/bill.query.php
+++ b/demo/bill.query.php
@@ -1,15 +1,18 @@
 <?php
 require_once("../loader.php");
+require_once("config.php");
 
-$data = array();
-$appSecret = TEST_MODE ? TEST_SECRET : APP_SECRET;
-$data["app_id"] = APP_ID;
+//设置app id, app secret, master secret, test secret
+$api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
+//Test Model,只提供下单和支付订单查询的Sandbox模式,不写setMode函数或者false即live模式,true即test模式
+$api->setMode(false);
+
 $data["timestamp"] = time() * 1000;
-$data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $appSecret);
 //只列出了支付成功的订单
 $data["spay_result"] = true;
 $data["limit"] = 10;
-//退款单号
+
+//退款单号,为(预)退款使用的
 $refund_no = date('Ymd',time()).time() * 1000;
 
 $type = $_GET['type'];
@@ -64,49 +67,49 @@ switch($type){
 </head>
 <body>
 <table border="1" align="center" cellspacing=0>
-<?php
-try {
-    $result = $api->bills($data);
-    if ($result->result_code != 0 || $result->result_msg != "OK") {
-        print_r($result);
-        exit();
-    }
-    $bills = $result->bills;
-    $str = "<tr><th>ID</th><th>同意退款</th><th>预退款</th><th>是否支付</th><th>创建时间</th><th>总价(分)</th><th>渠道类型</th><th>订单号</th><th>订单标题</th></tr>";
-    foreach($bills as $list) {
-        $refund = true;
-        $pre_refund = true;
-        $type = trim($list->channel);
-        if(in_array($list->sub_channel, array('ALI_OFFLINE_QRCODE', 'ALI_SCAN', 'WX_SCAN', 'WX_NATIVE'))){
-            $type = trim($list->sub_channel);
-            $pre_refund = false;
+    <?php
+    try {
+        $result = $api->bills($data);
+        if ($result->result_code != 0 || $result->result_msg != "OK") {
+            print_r($result);
+            exit();
         }
-        if($type == 'BC'){
-            $refund = false;
-            $pre_refund = false;
-        }
-        $strParams = "agree.refund.php?type=$type&refund_no=".$refund_no."&bill_no=".$list->bill_no."&refund_fee=".$list->total_fee;
-        $agree_refund = $list->spay_result&&!$list->refund_result&&$refund ? "<a href='".$strParams."' target='_blank'>退款</a>" : "";
-        $prep_refund = $list->spay_result&&!$list->refund_result&&$pre_refund ? "<a href='".$strParams."&need_approval=true' target='_blank'>预退款</a>" : "";
-        $spay_result = $list->spay_result ? ($list->refund_result ? '已退款' : '支付') : '未支付';
-        $create_time = $list->create_time ? date ( 'Y-m-d H:i:s', $list->create_time / 1000 ) : '';
-        $str .= "<tr><td>$list->id</td><td>$agree_refund</td><td>$prep_refund</td><td>$spay_result</td><td>$create_time</td><td>{$list->total_fee}</td><td>{$list->sub_channel}</td>
+        $bills = $result->bills;
+        $str = "<tr><th>ID</th><th>同意退款</th><th>预退款</th><th>是否支付</th><th>创建时间</th><th>总价(分)</th><th>渠道类型</th><th>订单号</th><th>订单标题</th></tr>";
+        foreach($bills as $list) {
+            $refund = true;
+            $pre_refund = true;
+            $type = trim($list->channel);
+            if(in_array($list->sub_channel, array('ALI_OFFLINE_QRCODE', 'ALI_SCAN', 'WX_SCAN', 'WX_NATIVE'))){
+                $type = trim($list->sub_channel);
+                $pre_refund = false;
+            }
+            if($type == 'BC' || $type == 'PAYPAL'){
+                $refund = false;
+                $pre_refund = false;
+            }
+            $strParams = "agree.refund.php?type=$type&refund_no=".$refund_no."&bill_no=".$list->bill_no."&refund_fee=".$list->total_fee;
+            $agree_refund = $list->spay_result&&!$list->refund_result&&$refund ? "<a href='".$strParams."' target='_blank'>退款</a>" : "";
+            $prep_refund = $list->spay_result&&!$list->refund_result&&$pre_refund ? "<a href='".$strParams."&need_approval=true' target='_blank'>预退款</a>" : "";
+            $spay_result = $list->spay_result ? ($list->refund_result ? '已退款' : '支付') : '未支付';
+            $create_time = $list->create_time ? date ( 'Y-m-d H:i:s', $list->create_time / 1000 ) : '';
+            $str .= "<tr><td>$list->id</td><td>$agree_refund</td><td>$prep_refund</td><td>$spay_result</td><td>$create_time</td><td>{$list->total_fee}</td><td>{$list->sub_channel}</td>
             	<td>{$list->bill_no}</td><td>{$list->title}</td></tr>";
-    }
-    echo $str;
+        }
+        echo $str;
 
-    unset($data["limit"]);
-    $result = $api->bills_count($data);
-    if ($result->result_code != 0 || $result->result_msg != "OK") {
-        print_r($result);
-        exit();
+        unset($data["limit"]);
+        $result = $api->bills_count($data);
+        if ($result->result_code != 0 || $result->result_msg != "OK") {
+            print_r($result);
+            exit();
+        }
+        $count = $result->count;
+        echo '<tr><td colspan="1">支付订单总数:</td><td colspan="8">'.$count.'</td></tr>';
+    } catch (Exception $e) {
+        echo $e->getMessage();
     }
-    $count = $result->count;
-    echo '<tr><td colspan="1">支付订单总数:</td><td colspan="8">'.$count.'</td></tr>';
-} catch (Exception $e) {
-    echo $e->getMessage();
-}
-?>
+    ?>
 </table>
 </body>
 </html>

--- a/demo/config.php
+++ b/demo/config.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ *  set beecloud pay main params
+ *
+ */
+
+const APP_ID = 'c5d1cba1-5e3f-4ba0-941d-9b0a371fe719';
+const APP_SECRET = '39a7a518-9ac8-4a9e-87bc-7885f33cf18c';
+//test_secret for sandbox
+const TEST_SECRET = '4bfdd244-574d-4bf3-b034-0c751ed34fee';
+const MASTER_SECRET = 'e14ae2db-608c-4f8b-b863-c8c18953eef2';

--- a/demo/pay.bill.php
+++ b/demo/pay.bill.php
@@ -1,11 +1,22 @@
 <?php
 require_once("../loader.php");
+require_once("config.php");
+
+/* registerApp fun need four params:
+ * @param(first) $app_id beecloud平台的APP ID
+ * @param(second) $app_secret  beecloud平台的APP SECRET
+ * @param(third) $master_secret  beecloud平台的MASTER SECRET
+ * @param(fouth) $test_secret  beecloud平台的TEST SECRET, for sandbox
+ */
+$api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
+//Test Model,只提供下单和支付订单查询的Sandbox模式,不写setMode函数或者false即live模式,true即test模式
+$api->setMode(false);
+
+//\beecloud\rest\api::registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
+//\beecloud\rest\api::setMode(false);
 
 $data = array();
-$appSecret = TEST_MODE ? TEST_SECRET : APP_SECRET;
-$data["app_id"] = APP_ID;
 $data["timestamp"] = time() * 1000;
-$data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $appSecret);
 //total_fee(int 类型) 单位分
 $data["total_fee"] = 1;
 $data["bill_no"] = "bcdemo" . $data["timestamp"];
@@ -177,6 +188,7 @@ switch($type){
          * NJCB   南京银行    SRCB   上海农商行 BOB   北京银行
         */
         $data["bank"] = "BOC";
+        $title = "BC网关支付";
         break;
     case 'BC_EXPRESS' :
         $data["channel"] = "BC_EXPRESS";
@@ -184,6 +196,7 @@ switch($type){
         $data["total_fee"] = 100;
         //银行卡卡号, 选填
         //$data["card_no"] = '622269192199384xxxx';
+        $title = "BC快捷支付";
         break;
     default :
         exit("No this type.");

--- a/demo/prep.refund.php
+++ b/demo/prep.refund.php
@@ -3,12 +3,11 @@
  * 批量审核接口仅支持预退款，批量审核分为批量驳回和批量同意。
  */
 require_once("../loader.php");
+require_once("config.php");
 
-$data = array();
-$masterSecret = MASTER_SECRET;
-$data["app_id"] = APP_ID;
+//设置app id, app secret, master secret, test secret
+$api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
 $data["timestamp"] = time() * 1000;
-$data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $masterSecret);
 //agree, boolean: 批量驳回传false，批量同意传true
 $data["agree"] = true;
 //deny_reason选填, 驳回理由
@@ -70,23 +69,23 @@ switch($type){
 </head>
 <body>
 <?php
-    try {
-        $result = $api->refund($data, 'put');
-        if ($result->result_code != 0 || $result->result_msg != "OK") {
-            print_r($result);
-            exit();
-        }
-        //agree为true时,支付宝退款地址，需用户在支付宝平台上手动输入支付密码处理
-        if($data["channel"] == 'ALI'){
-            header("Location:$result->url");
-            exit();
-        }
-        //agree为true时,批量同意单笔结果集合，key:单笔记录id; value:此笔记录结果。
-        //当退款处理成功时，value值为"OK"；当退款处理失败时， value值为具体的错误信息。
-        print_r($result->result_map);
-    } catch (Exception $e) {
-        echo $e->getMessage();
+try {
+    $result = $api->refund($data, 'put');
+    if ($result->result_code != 0 || $result->result_msg != "OK") {
+        print_r($result);
+        exit();
     }
+    //agree为true时,支付宝退款地址，需用户在支付宝平台上手动输入支付密码处理
+    if($data["channel"] == 'ALI'){
+        header("Location:$result->url");
+        exit();
+    }
+    //agree为true时,批量同意单笔结果集合，key:单笔记录id; value:此笔记录结果。
+    //当退款处理成功时，value值为"OK"；当退款处理失败时， value值为具体的错误信息。
+    print_r($result->result_map);
+} catch (Exception $e) {
+    echo $e->getMessage();
+}
 ?>
 </body>
 </html>

--- a/demo/preprefund.query.php
+++ b/demo/preprefund.query.php
@@ -1,11 +1,10 @@
 <?php
 require_once("../loader.php");
+require_once("config.php");
 
-$data = array();
-$appSecret = APP_SECRET;
-$data["app_id"] = APP_ID;
+//设置app id, app secret, master secret, test secret
+$api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
 $data["timestamp"] = time() * 1000;
-$data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $appSecret);
 $data["need_approval"] = true;
 $data["limit"] = 10;
 
@@ -66,7 +65,7 @@ switch($type){
     2.当channel为ALI时，如果退款成功，返回参数中包含支付宝退款地址，需用户在支付宝平台上手动输入支付密码处理！
 </h3>
 <table border="1" align="center" cellspacing=0>
-<?php
+    <?php
     try {
         $result = $api->refunds($data);
         if ($result->result_code != 0 || $result->result_msg != "OK") {
@@ -97,7 +96,7 @@ switch($type){
     } catch (Exception $e) {
         echo $e->getMessage();
     }
-?>
+    ?>
 </table>
 
 <input onclick="approve_pre_refunds()" type="button" class="button_blue" value="同意预退款" />

--- a/demo/query.byid.php
+++ b/demo/query.byid.php
@@ -7,58 +7,58 @@
 </head>
 <body>
 <table border="1" align="center" cellspacing=0>
-<?php
-require_once("../loader.php");
+    <?php
+    require_once("../loader.php");
+    require_once("config.php");
 
-$data = array();
-$appSecret = APP_SECRET;
-$data["app_id"] = APP_ID;
-$data["timestamp"] = time() * 1000;
-$data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $appSecret);
-$data["id"] = $_GET['id'];
-$type = $_GET['type'];
+    //设置app id, app secret, master secret, test secret
+    $api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
 
-if(empty($data["id"])){
-    exit(json_encode(array('result_code' => 1, 'err_detail' => '请输入id')));
-}
-try {
-    switch($type){
-        case 'bill':
-            $result = $api->bill($data, 'get');
-            if ($result->result_code != 0 || $result->result_msg != "OK") {
-                print_r($result);
-                exit();
-            }
-            $data = $result->pay;
-            $str = "<tr><th>是否支付</th><th>创建时间</th><th>总价(分)</th><th>渠道类型</th><th>订单号</th><th>订单标题</th></tr>";
-            if($data){
-                $create_time = isset($data->create_time) && $data->create_time ? date('Y-m-d H:i:s', $data->create_time/1000) : '';
-                $spay_result = $data->spay_result ? '支付' : '未支付';
-                $str .= "<tr><td>$spay_result</td><td>$create_time</td><td>$data->total_fee</td><td>$data->sub_channel</td><td>$data->bill_no</td><td>$data->title</td></tr>";
-            }
-            echo $str;
-            break;
-        case 'refund':
-            $result = $api->refund($data, 'get');
-            if ($result->result_code != 0 || $result->result_msg != "OK") {
-                print_r($result);
-                exit();
-            }
-            $data = $result->refund;
-            $str = "<tr><th>退款是否成功</th><th>退款创建时间</th><th>退款号</th><th>订单金额(分)</th><th>退款金额(分)</th><th>渠道类型</th><th>订单号</th><th>退款是否完成</th><th>订单标题</th></tr>";
-            if($data){
-                $create_time = isset($data->create_time) && $data->create_time ? date('Y-m-d H:i:s', $data->create_time/1000) : '';
-                $result = $data->result ? "成功" : "失败";
-                $finish = $data->finish ? "完成" : "未完成";
-                $str .= "<tr><td>$result</td><td>$create_time</td><td>$data->refund_no</td><td>$data->total_fee</td><td>$data->refund_fee</td><td>$data->sub_channel</td><td>$data->bill_no</td><td>$finish</td><td>$data->title</td></tr>";
-            }
-            echo $str;
-            break;
+    $data["timestamp"] = time() * 1000;
+    $data["id"] = $_GET['id'];
+    $type = $_GET['type'];
+
+    if(empty($data["id"])){
+        exit(json_encode(array('result_code' => 1, 'err_detail' => '请输入id')));
     }
-} catch (Exception $e) {
-    die($e->getMessage());
-}
-?>
+    try {
+        switch($type){
+            case 'bill':
+                $result = $api->bill($data, 'get');
+                if ($result->result_code != 0 || $result->result_msg != "OK") {
+                    print_r($result);
+                    exit();
+                }
+                $data = $result->pay;
+                $str = "<tr><th>是否支付</th><th>创建时间</th><th>总价(分)</th><th>渠道类型</th><th>订单号</th><th>订单标题</th></tr>";
+                if($data){
+                    $create_time = isset($data->create_time) && $data->create_time ? date('Y-m-d H:i:s', $data->create_time/1000) : '';
+                    $spay_result = $data->spay_result ? '支付' : '未支付';
+                    $str .= "<tr><td>$spay_result</td><td>$create_time</td><td>$data->total_fee</td><td>$data->sub_channel</td><td>$data->bill_no</td><td>$data->title</td></tr>";
+                }
+                echo $str;
+                break;
+            case 'refund':
+                $result = $api->refund($data, 'get');
+                if ($result->result_code != 0 || $result->result_msg != "OK") {
+                    print_r($result);
+                    exit();
+                }
+                $data = $result->refund;
+                $str = "<tr><th>退款是否成功</th><th>退款创建时间</th><th>退款号</th><th>订单金额(分)</th><th>退款金额(分)</th><th>渠道类型</th><th>订单号</th><th>退款是否完成</th><th>订单标题</th></tr>";
+                if($data){
+                    $create_time = isset($data->create_time) && $data->create_time ? date('Y-m-d H:i:s', $data->create_time/1000) : '';
+                    $result = $data->result ? "成功" : "失败";
+                    $finish = $data->finish ? "完成" : "未完成";
+                    $str .= "<tr><td>$result</td><td>$create_time</td><td>$data->refund_no</td><td>$data->total_fee</td><td>$data->refund_fee</td><td>$data->sub_channel</td><td>$data->bill_no</td><td>$finish</td><td>$data->title</td></tr>";
+                }
+                echo $str;
+                break;
+        }
+    } catch (Exception $e) {
+        die($e->getMessage());
+    }
+    ?>
 </table>
 </body>
 </html>

--- a/demo/refund.changestatus.php
+++ b/demo/refund.changestatus.php
@@ -1,11 +1,10 @@
 <?php
 require_once("../loader.php");
+require_once("config.php");
 
-$data = array();
-$appSecret = APP_SECRET;
-$data["app_id"] = APP_ID;
+//设置app id, app secret, master secret, test secret
+$api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
 $data["timestamp"] = time() * 1000;
-$data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $appSecret);
 $data["channel"] = $_GET['channel'];
 $data["refund_no"] = $_GET["refund_no"];
 try {

--- a/demo/refund.query.php
+++ b/demo/refund.query.php
@@ -1,12 +1,10 @@
 <?php
 require_once("../loader.php");
+require_once("config.php");
 
-$data = array();
-$appSecret = APP_SECRET;
-$data["app_id"] = APP_ID;
+//设置app id, app secret, master secret, test secret
+$api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
 $data["timestamp"] = time() * 1000;
-$data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $appSecret);
-
 $data["limit"] = 10;
 
 $type = $_GET['type'];
@@ -62,7 +60,7 @@ switch($type){
 <body>
 <h3>注意:退款状态更新接口提供查询退款状态以更新退款状态的功能，用于对退款后不发送回调的渠道（WX、YEE、KUAIQIAN、BD）退款后的状态更新。</h3>
 <table border="1" align="center" cellspacing=0>
-<?php
+    <?php
     try {
         $result = $api->refunds($data);
         if ($result->result_code != 0 || $result->result_msg != "OK") {
@@ -96,7 +94,7 @@ switch($type){
     } catch (Exception $e) {
         echo $e->getMessage();
     }
-?>
+    ?>
 </table>
 </body>
 </html>

--- a/demo/transfer.bill.php
+++ b/demo/transfer.bill.php
@@ -1,11 +1,11 @@
 <?php
 require_once("../loader.php");
+require_once("config.php");
 
-$data = array();
-$masterSecret = MASTER_SECRET;
-$data["app_id"] = APP_ID;
+//设置app id, app secret, master secret, test secret
+$api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
+
 $data["timestamp"] = time() * 1000;
-$data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $masterSecret);
 $data["total_fee"] = 1;
 $data["desc"] = "transfer test";
 
@@ -62,6 +62,7 @@ switch($type) {
         );
         break;
     case 'BC_TRANSFER' :
+        $title = 'BC企业打款';
         unset($data['desc']);
         $data["bill_no"] = "bcdemo" . $data["timestamp"];
         $data["title"] = 'PHP测试BC企业打款';
@@ -99,31 +100,31 @@ switch($type) {
 </head>
 <body>
 <?php
-    try {
-        switch($type){
-            case 'ALI_TRANSFERS':
-                $result = $api->transfers($data);
-                break;
-            case 'BC_TRANSFER':
-                $result = $api->bc_transfer($data);
-                break;
-            default :
-                $result = $api->transfer($data);
-                break;
+try {
+    switch($type){
+        case 'ALI_TRANSFERS':
+            $result = $api->transfers($data);
+            break;
+        case 'BC_TRANSFER':
+            $result = $api->bc_transfer($data);
+            break;
+        default :
+            $result = $api->transfer($data);
+            break;
 
-        }
-        if ($result->result_code != 0) {
-            print_r($result);
-            exit();
-        }
-        if(isset($result->url)){
-            header("Location:$result->url");
-        }else{
-            echo '下发成功!';
-        }
-    } catch (Exception $e) {
-        echo $e->getMessage();
     }
+    if ($result->result_code != 0) {
+        print_r($result);
+        exit();
+    }
+    if(isset($result->url)){
+        header("Location:$result->url");
+    }else{
+        echo '下发成功!';
+    }
+} catch (Exception $e) {
+    echo $e->getMessage();
+}
 ?>
 </body>
 </table>

--- a/demo/wx/wx.native.query.php
+++ b/demo/wx/wx.native.query.php
@@ -1,15 +1,14 @@
 <?php
 require_once("../../loader.php");
+require_once("../config.php");
 
-$data = array();
-$appSecret = APP_SECRET;
-$data["app_id"] = APP_ID;
+//设置app id, app secret, master secret, test secret
+$api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
+
 $data["timestamp"] = time() * 1000;
-$data["app_sign"] = md5($data["app_id"] . $data["timestamp"] . $appSecret);
 $data["bill_no"] = $_GET["billNo"];
 //选填 channel
 $data["channel"] = "WX_NATIVE";
 
 $result = $api->bills($data);
 print json_encode($result);
-

--- a/loader.php
+++ b/loader.php
@@ -1,6 +1,6 @@
 <?php
-require_once("sdk/src/rest/config.php");
-if(version_compare(PHP_VERSION, '5.3.0','>')) {
+if(version_compare(PHP_VERSION, '7.3.0','>')) {
+    require_once("sdk/src/rest/config.php");
     require_once("sdk/src/rest/network.php");
     require_once("sdk/src/rest/api.php");
     $api = new \beecloud\rest\api();

--- a/sdk/src/beecloud.php
+++ b/sdk/src/beecloud.php
@@ -4,6 +4,78 @@
  *
  */
 
+class APIConfig {
+
+    const URI_BILL = '/2/rest/bill'; //支付;支付订单查询(指定id)
+    const URI_TEST_BILL = '/2/rest/sandbox/bill';
+    const URI_BILLS = '/2/rest/bills'; //订单查询
+    const URI_TEST_BILLS = '/2/rest/sandbox/bills';
+    const URI_BILLS_COUNT = '/2/rest/bills/count'; //订单总数查询
+    const URI_TEST_BILLS_COUNT = '/2/rest/sandbox/bills/count';
+
+    const URI_REFUND = "/2/rest/refund";		//退款;预退款批量审核;退款订单查询(指定id)
+    const URI_REFUNDS = "/2/rest/refunds";		//退款查询
+    const URI_REFUNDS_COUNT = "/2/rest/refunds/count"; //退款总数查询
+    const URI_REFUND_STATUS = "/2/rest/refund/status"; //退款状态更新
+
+    const URI_TRANSFERS = "/2/rest/transfers"; //批量打款 - 支付宝
+    const URI_TRANSFER = "/2/rest/transfer";  //单笔打款 - 支付宝/微信
+    const URI_BC_TRANSFER_BANKS = '/2/rest/bc_transfer/banks'; //BC企业打款 - 支持银行
+    const URI_BC_TRANSFER = "/2/rest/bc_transfer"; //代付 - 银行卡
+
+    const URI_OFFLINE_BILL = '/2/rest/offline/bill'; //线下支付-撤销订单
+    const URI_OFFLINE_BILL_STATUS = '/2/rest/offline/bill/status'; //线下订单状态查询
+    const URI_OFFLINE_REFUND = '/2/rest/offline/refund'; //线下退款
+
+    const URI_INTERNATIONAL_BILL = "/1/rest/international/bill";
+    const URI_INTERNATIONAL_REFUND = "/1/rest/international/refund";
+
+
+    const UNEXPECTED_RESULT = "非预期的返回结果:";
+    const NEED_PARAM = "需要必填字段:";
+    const NEED_VALID_PARAM = "字段值不合法:";
+    const NEED_WX_JSAPI_OPENID = "微信公众号支付(WX_JSAPI) 需要openid字段";
+    const NEED_RETURN_URL = "当channel参数为 ALI_WEB 或 ALI_QRCODE 或 UN_WEB 或JD_WAP 或 JD_WEB时 return_url为必填";
+    const NEED_IDENTITY_ID = "当channel参数为 YEE_WAP时 identity_id为必填";
+    const BILL_TIMEOUT_ERROR = "当channel参数为 JD* 不支持bill_timeout";
+    const NEED_QR_PAY_MODE = '当channel参数为 ALI_QRCODE时 qr_pay_mode为必填';
+    const NEED_CARDNO = '当channel参数为 YEE_NOBANKCARD时 cardno为必填';
+    const NEED_CARDPWD = '当channel参数为 YEE_NOBANKCARD时 cardpwd为必填';
+    const NEED_FRQID = '当channel参数为 YEE_NOBANKCARD时 frqid为必填';
+    const NEED_TOTAL_FEE = '当channel参数为 BC_EXPRESS时 total_fee单位分,最小金额100分';
+    const VALID_BC_PARAM = 'APP ID,APP Secret,Master Secret参数值均不能为空,请重新设置';
+    const VALID_SIGN_PARAM = 'APP ID, timestamp,APP(Master) Secret参数值均不能为空,请设置';
+    const VALID_MASTER_SECRET = 'Master Secret参数值不能为空,请设置';
+    const VALID_APP_SECRET = 'APP Secret参数值不能为空,请设置';
+
+    /*
+	 * bank_code(int 类型) for channel JD_B2B
+		9102    中国工商银行      9107    招商银行
+		9103    中国农业银行      9108    光大银行
+		9104    交通银行         9109    中国银行
+		9105    中国建设银行		9110 	 平安银行
+	*/
+    static function get_bank_code(){
+        return array(9102, 9103, 9104, 9105, 9107, 9108, 9109, 9110);
+    }
+
+    /*
+	 * bank(string 类型) for channel BC_GATEWAY
+	 * CMB	  招商银行    ICBC	工商银行   CCB   建设银行(暂不支持)
+	 * BOC	  中国银行    ABC    农业银行   BOCM	交通银行
+	 * SPDB   浦发银行    GDB	广发银行   CITIC	中信银行
+	 * CEB	  光大银行    CIB	兴业银行   SDB	平安银行
+	 * CMBC   民生银行    NBCB   宁波银行   BEA   东亚银行
+	 * NJCB   南京银行    SRCB   上海农商行 BOB   北京银行
+	*/
+    static function get_bank(){
+        return array(
+            'CMB', 'ICBC', 'CCB', 'BOC', 'ABC', 'BOCM', 'SPDB', 'GDB', 'CITIC',
+            'CEB', 'CIB', 'SDB', 'CMBC', 'NBCB', 'BEA', 'NJCB', 'SRCB', 'BOB'
+        );
+    }
+}
+
 class BCRESTUtil {
     static final public function getApiUrl() {
         $domainList = array("apibj.beecloud.cn", "apisz.beecloud.cn", "apiqd.beecloud.cn", "apihz.beecloud.cn");
@@ -21,7 +93,7 @@ class BCRESTUtil {
         $httpResultStr = BCRESTUtil::request($url, "post", $data, $timeout);
         $result = json_decode($httpResultStr);
         if (!$result) {
-            throw new Exception(UNEXPECTED_RESULT . $httpResultStr);
+            throw new Exception(APIConfig::UNEXPECTED_RESULT . $httpResultStr);
         }
         return $result;
     }
@@ -31,7 +103,7 @@ class BCRESTUtil {
         $httpResultStr = BCRESTUtil::request($url, "get", $data, $timeout);
         $result = json_decode($httpResultStr);
         if (!$result) {
-            throw new Exception(UNEXPECTED_RESULT . $httpResultStr);
+            throw new Exception(APIConfig::UNEXPECTED_RESULT . $httpResultStr);
         }
         return $result;
     }
@@ -41,7 +113,7 @@ class BCRESTUtil {
         $httpResultStr = BCRESTUtil::request($url, "put", $data, $timeout);
         $result = json_decode($httpResultStr,!$returnArray ? false : true);
         if (!$result) {
-            throw new Exception(UNEXPECTED_RESULT . $httpResultStr);
+            throw new Exception(APIConfig::UNEXPECTED_RESULT . $httpResultStr);
         }
         return $result;
     }
@@ -109,78 +181,120 @@ class BCRESTInternational {
 
     static final private function baseParamCheck(array $data) {
         if (!isset($data["app_id"])) {
-            throw new Exception(NEED_PARAM . "app_id");
+            throw new Exception(APIConfig::NEED_PARAM . "app_id");
         }
 
         if (!isset($data["timestamp"])) {
-            throw new Exception(NEED_PARAM . "timestamp");
+            throw new Exception(APIConfig::NEED_PARAM . "timestamp");
         }
 
         if (!isset($data["app_sign"])) {
-            throw new Exception(NEED_PARAM . "app_sign");
+            throw new Exception(APIConfig::NEED_PARAM . "app_sign");
         }
 
         if (!isset($data["currency"])) {
-            throw new Exception(NEED_PARAM . "currency");
+            throw new Exception(APIConfig::NEED_PARAM . "currency");
         }
     }
 
     static final public function bill(array $data) {
+        $data["app_id"] = BCRESTApi::$app_id;
+        $data["app_sign"] = BCRESTApi::get_sign($data["app_id"], $data["timestamp"], BCRESTApi::$app_secret);
         //param validation
         self::baseParamCheck($data);
 
         switch ($data["channel"]) {
             case "PAYPAL_PAYPAL":
                 if (!isset($data["return_url"])) {
-                    throw new Exception(NEED_PARAM . "return_url");
+                    throw new Exception(APIConfig::NEED_PARAM . "return_url");
                 }
                 break;
             case "PAYPAL_CREDITCARD":
                 if (!isset($data["credit_card_info"])) {
-                    throw new Exception(NEED_PARAM . "credit_card_info");
+                    throw new Exception(APIConfig::NEED_PARAM . "credit_card_info");
                 }
                 break;
             case "PAYPAL_SAVED_CREDITCARD":
                 if (!isset($data["credit_card_id"])) {
-                    throw new Exception(NEED_PARAM . "credit_card_id");
+                    throw new Exception(APIConfig::NEED_PARAM . "credit_card_id");
                 }
                 break;
             default:
-                throw new Exception(NEED_VALID_PARAM . "channel");
+                throw new Exception(APIConfig::NEED_VALID_PARAM . "channel");
                 break;
         }
 
         if (!isset($data["total_fee"])) {
-            throw new Exception(NEED_PARAM . "total_fee");
+            throw new Exception(APIConfig::NEED_PARAM . "total_fee");
         } else if(!is_int($data["total_fee"]) || $data["total_fee"] < 1) {
-            throw new Exception(NEED_VALID_PARAM . "total_fee");
+            throw new Exception(APIConfig::NEED_VALID_PARAM . "total_fee");
         }
 
         if (!isset($data["bill_no"])) {
-            throw new Exception(NEED_PARAM . "bill_no");
+            throw new Exception(APIConfig::NEED_PARAM . "bill_no");
         }
 
         if (!isset($data["title"])) {
-            throw new Exception(NEED_PARAM . "title");
+            throw new Exception(APIConfig::NEED_PARAM . "title");
         }
 
-        return BCRESTUtil::post(URI_INTERNATIONAL_BILL, $data, 30, false);
+        return BCRESTUtil::post(APIConfig::URI_INTERNATIONAL_BILL, $data, 30, false);
     }
 }
 
 class BCRESTApi {
 
+    //BeeCloud main pay params
+    public static $app_id;
+    public static $app_secret;
+    public static $master_secret;
+    public static $test_secret;
+
+    //Test Model,只提供下单和支付订单查询的Sandbox模式
+    public static $mode = false;
+
+    static function getMode(){
+        return self::$mode;
+    }
+
+    static function setMode($flag = false){
+        self::$mode = $flag;
+    }
+
+    /*
+	 * @param $app_id beecloud平台的APP ID
+	 * @param $app_secret  beecloud平台的APP SECRET
+	 * @param $master_secret  beecloud平台的MASTER SECRET
+	 * @param $test_secret  beecloud平台的TEST SECRET
+	 */
+    static function registerApp($app_id, $app_secret, $master_secret = '', $test_secret = ''){
+        if(empty($app_id) || empty($app_secret) || empty($master_secret)){
+            throw new Exception(APIConfig::VALID_BC_PARAM);
+        }
+        self::$app_id = $app_id;
+        self::$app_secret = $app_secret;
+        self::$master_secret = $master_secret;
+        self::$test_secret = $test_secret;
+    }
+
+    static function get_sign($app_id, $timestamp, $secret){
+        if(empty($app_id) || empty($timestamp) || empty($secret)){
+            throw new Exception(APIConfig::VALID_SIGN_PARAM);
+        }
+        return md5($app_id.$timestamp.$secret);
+    }
+
     static final private function baseParamCheck(array $data) {
         if (!isset($data["app_id"])) {
-            throw new Exception(NEED_PARAM . "app_id");
+            throw new Exception(APIConfig::NEED_PARAM . "app_id");
         }
 
         if (!isset($data["timestamp"])) {
-            throw new Exception(NEED_PARAM . "timestamp");
+            throw new Exception(APIConfig::NEED_PARAM . "timestamp");
         }
 
         if (!isset($data["app_sign"])) {
-            throw new Exception(NEED_PARAM . "app_sign");
+            throw new Exception(APIConfig::NEED_PARAM . "app_sign");
         }
     }
 
@@ -190,6 +304,8 @@ class BCRESTApi {
      * @throws Exception
      */
     static final public function bill(array $data, $method = 'post') {
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
         //param validation
         self::baseParamCheck($data);
         self::channelCheck($data);
@@ -202,9 +318,9 @@ class BCRESTApi {
                 case 'JD_WEB':
                 case 'JD_B2B':
                 case "BC_GATEWAY":
-                //case "BC_EXPRESS":
+                    //case "BC_EXPRESS":
                     if (!isset($data["return_url"])) {
-                        throw new Exception(NEED_RETURN_URL);
+                        throw new Exception(APIConfig::NEED_RETURN_URL);
                     }
                     break;
             }
@@ -212,96 +328,96 @@ class BCRESTApi {
             switch ($data["channel"]) {
                 case "WX_JSAPI":
                     if (!isset($data["openid"])) {
-                        throw new Exception(NEED_WX_JSAPI_OPENID);
+                        throw new Exception(APIConfig::NEED_WX_JSAPI_OPENID);
                     }
                     break;
                 case "ALI_QRCODE":
                     if (!isset($data["qr_pay_mode"])) {
-                        throw new Exception(NEED_QR_PAY_MODE);
+                        throw new Exception(APIConfig::NEED_QR_PAY_MODE);
                     }
                     break;
                 case "JD_B2B":
                     if (!isset($data["bank_code"])) {
-                        throw new Exception(NEED_PARAM.'bank_code');
+                        throw new Exception(APIConfig::NEED_PARAM.'bank_code');
                     }
-                    if (!in_array($data["bank_code"], unserialize(BANK_CODE))) {
-                        throw new Exception(NEED_VALID_PARAM.'bank_code');
+                    if (!in_array($data["bank_code"], APIConfig::get_bank_code())) {
+                        throw new Exception(APIConfig::NEED_VALID_PARAM.'bank_code');
                     }
                     break;
                 case "YEE_WAP":
                     if (!isset($data["identity_id"])) {
-                        throw new Exception(NEED_IDENTITY_ID);
+                        throw new Exception(APIConfig::NEED_RETURN_URL);
                     }
                     break;
                 case "YEE_NOBANKCARD":
                     if (!isset($data["cardno"])) {
-                        throw new Exception(NEED_CARDNO);
+                        throw new Exception(APIConfig::NEED_CARDNO);
                     }
                     if (!isset($data["cardpwd"])) {
-                        throw new Exception(NEED_CARDPWD);
+                        throw new Exception(APIConfig::NEED_CARDPWD);
                     }
                     if (!isset($data["frqid"])) {
-                        throw new Exception(NEED_FRQID);
+                        throw new Exception(APIConfig::NEED_FRQID);
                     }
                     break;
                 case "JD_WEB":
                 case "JD_WAP":
                     if (isset($data["bill_timeout"])) {
-                        throw new Exception(BILL_TIMEOUT_ERROR);
+                        throw new Exception(APIConfig::BILL_TIMEOUT_ERROR);
                     }
                     break;
                 case "KUAIQIAN_WAP":
                 case "KUAIQIAN_WEB":
 //                    if (isset($data["bill_timeout"])) {
-//                        throw new Exception(BILL_TIMEOUT_ERROR);
+//                        throw new Exception(APIConfig::BILL_TIMEOUT_ERROR);
 //                    }
 //                    break;
                 case "BC_GATEWAY":
                     if (!isset($data["bank"])) {
-                        throw new Exception(NEED_PARAM.'bank');
+                        throw new Exception(APIConfig::NEED_PARAM.'bank');
                     }
-                    if (!in_array($data["bank"], unserialize(BANK))) {
-                        throw new Exception(NEED_VALID_PARAM.'bank');
+                    if (!in_array($data["bank"], APIConfig::get_bank())) {
+                        throw new Exception(APIConfig::NEED_VALID_PARAM.'bank');
                     }
                     break;
                 case "BC_EXPRESS" :
                     if ($data["total_fee"] < 100 || !is_int($data["total_fee"])) {
-                        throw new Exception(NEED_TOTAL_FEE);
+                        throw new Exception(APIConfig::NEED_TOTAL_FEE);
                     }
                     break;
             }
         }
-
+        $url = BCRESTApi::getMode() ? APIConfig::URI_TEST_BILL : APIConfig::URI_BILL;
         switch ($method) {
             case 'get'://支付订单查询
                 if (!isset($data["id"])) {
-                    throw new Exception(NEED_PARAM . "id");
+                    throw new Exception(APIConfig::NEED_PARAM . "id");
                 }
                 $order_id = $data["id"];
                 unset($data["id"]);
-                return BCRESTUtil::get(URI_BILL.'/'.$order_id, $data, 30, false);
+                return BCRESTUtil::get($url.'/'.$order_id, $data, 30, false);
                 break;
             case 'post': // 支付
                 if (!isset($data["channel"])) {
-                    throw new Exception(NEED_PARAM . "channel");
+                    throw new Exception(APIConfig::NEED_PARAM . "channel");
                 }
                 if (!isset($data["total_fee"])) {
-                    throw new Exception(NEED_PARAM . "total_fee");
+                    throw new Exception(APIConfig::NEED_PARAM . "total_fee");
                 } else if(!is_int($data["total_fee"]) || 1>$data["total_fee"]) {
-                    throw new Exception(NEED_VALID_PARAM . "total_fee");
+                    throw new Exception(APIConfig::NEED_VALID_PARAM . "total_fee");
                 }
 
                 if (!isset($data["bill_no"])) {
-                    throw new Exception(NEED_PARAM . "bill_no");
+                    throw new Exception(APIConfig::NEED_PARAM . "bill_no");
                 }
                 if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
-                    throw new Exception(NEED_VALID_PARAM . "bill_no");
+                    throw new Exception(APIConfig::NEED_VALID_PARAM . "bill_no");
                 }
 
                 if (!isset($data["title"])) {
-                    throw new Exception(NEED_PARAM . "title");
+                    throw new Exception(APIConfig::NEED_PARAM . "title");
                 }
-                return BCRESTUtil::post(URI_BILL, $data, 30, false);
+                return BCRESTUtil::post($url, $data, 30, false);
                 break;
             default :
                 exit('No this method');
@@ -310,26 +426,37 @@ class BCRESTApi {
     }
 
     static final public function bills(array $data) {
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
         //required param existence check
         self::baseParamCheck($data);
         self::channelCheck($data);
 
+        $url = BCRESTApi::getMode() ? APIConfig::URI_TEST_BILLS : APIConfig::URI_BILLS;
         //param validation
-        return BCRESTUtil::get(URI_BILLS, $data, 30, false);
+        return BCRESTUtil::get($url, $data, 30, false);
     }
 
 
     static final public function bills_count(array $data){
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
         self::baseParamCheck($data);
         self::channelCheck($data);
 
         if (isset($data["bill_no"]) && !preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
-            throw new Exception(NEED_VALID_PARAM . "bill_no");
+            throw new Exception(APIConfig::NEED_VALID_PARAM . "bill_no");
         }
-        return BCRESTUtil::get(URI_BILLS_COUNT, $data, 30, false);
+        $url = BCRESTApi::getMode() ? APIConfig::URI_TEST_BILLS_COUNT : APIConfig::URI_BILLS_COUNT;
+        return BCRESTUtil::get($url, $data, 30, false);
     }
 
     static final public function refund(array $data, $method = 'post') {
+        if(empty(self::$master_secret)){
+            throw new Exception(APIConfig::VALID_MASTER_SECRET);
+        }
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], $method == 'get' ? self::$app_secret : self::$master_secret);
         //param validation
         self::baseParamCheck($data);
 
@@ -345,7 +472,7 @@ class BCRESTApi {
                 case "BC":
                     break;
                 default:
-                    throw new Exception(NEED_VALID_PARAM . "channel");
+                    throw new Exception(APIConfig::NEED_VALID_PARAM . "channel");
                     break;
             }
         }
@@ -353,69 +480,75 @@ class BCRESTApi {
         switch ($method){
             case 'put': //预退款批量审核
                 if (!isset($data["channel"])) {
-                    throw new Exception(NEED_PARAM . "channel");
+                    throw new Exception(APIConfig::NEED_PARAM . "channel");
                 }
                 if (!isset($data["ids"])) {
-                    throw new Exception(NEED_PARAM . "ids");
+                    throw new Exception(APIConfig::NEED_PARAM . "ids");
                 }
                 if (!is_array($data["ids"])) {
-                    throw new Exception(NEED_VALID_PARAM . "ids(array)");
+                    throw new Exception(APIConfig::NEED_VALID_PARAM . "ids(array)");
                 }
                 if (!isset($data["agree"])) {
-                    throw new Exception(NEED_PARAM . "agree");
+                    throw new Exception(APIConfig::NEED_PARAM . "agree");
                 }
-                return BCRESTUtil::put(URI_REFUND, $data, 30, false);
+                return BCRESTUtil::put(APIConfig::URI_REFUND, $data, 30, false);
                 break;
             case 'get'://退款订单查询
                 if (!isset($data["id"])) {
-                    throw new Exception(NEED_PARAM . "id");
+                    throw new Exception(APIConfig::NEED_PARAM . "id");
                 }
                 $order_id = $data["id"];
                 unset($data["id"]);
-                return BCRESTUtil::get(URI_REFUND.'/'.$order_id, $data, 30, false);
+                return BCRESTUtil::get(APIConfig::URI_REFUND.'/'.$order_id, $data, 30, false);
                 break;
             case 'post': //退款
             default :
                 if (!isset($data["bill_no"])) {
-                    throw new Exception(NEED_PARAM . "bill_no");
+                    throw new Exception(APIConfig::NEED_PARAM . "bill_no");
                 }
                 if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
-                    throw new Exception(NEED_VALID_PARAM . "bill_no");
+                    throw new Exception(APIConfig::NEED_VALID_PARAM . "bill_no");
                 }
 
                 if (!isset($data["refund_no"])) {
-                    throw new Exception(NEED_PARAM . "refund_no");
+                    throw new Exception(APIConfig::NEED_PARAM . "refund_no");
                 }
                 if (!preg_match('/^\d{8}[0-9A-Za-z]{3,24}$/', $data["refund_no"]) || preg_match('/^\d{8}0{3}/', $data["refund_no"])) {
-                    throw new Exception(NEED_VALID_PARAM . "refund_no");
+                    throw new Exception(APIConfig::NEED_VALID_PARAM . "refund_no");
                 }
 
                 if(!is_int($data["refund_fee"]) || 1>$data["refund_fee"]) {
-                    throw new Exception(NEED_VALID_PARAM . "refund_fee");
+                    throw new Exception(APIConfig::NEED_VALID_PARAM . "refund_fee");
                 }
-                return BCRESTUtil::post(URI_REFUND, $data, 30, false);
+                return BCRESTUtil::post(APIConfig::URI_REFUND, $data, 30, false);
                 break;
         }
     }
 
 
     static final public function refunds(array $data) {
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
         //required param existence check
         self::baseParamCheck($data);
         self::channelCheck($data);
         //param validation
-        return BCRESTUtil::get(URI_REFUNDS, $data, 30, false);
+        return BCRESTUtil::get(APIConfig::URI_REFUNDS, $data, 30, false);
     }
 
     static final public function refunds_count(array $data) {
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
         //required param existence check
         self::baseParamCheck($data);
         self::channelCheck($data);
         //param validation
-        return BCRESTUtil::get(URI_REFUNDS_COUNT, $data, 30, false);
+        return BCRESTUtil::get(APIConfig::URI_REFUNDS_COUNT, $data, 30, false);
     }
 
     static final public function refundStatus(array $data) {
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
         //required param existence check
         self::baseParamCheck($data);
 
@@ -426,24 +559,29 @@ class BCRESTApi {
             case "BD":
                 break;
             default:
-                throw new Exception(NEED_VALID_PARAM . "channel");
+                throw new Exception(APIConfig::NEED_VALID_PARAM . "channel");
                 break;
         }
 
         if (!isset($data["refund_no"])) {
-            throw new Exception(NEED_PARAM . "refund_no");
+            throw new Exception(APIConfig::NEED_PARAM . "refund_no");
         }
         //param validation
-        return BCRESTUtil::get(URI_REFUND_STATUS, $data, 30, false);
+        return BCRESTUtil::get(APIConfig::URI_REFUND_STATUS, $data, 30, false);
     }
 
     //单笔打款 - 支付宝/微信
     static final public function transfer(array $data) {
+        if(empty(self::$master_secret)){
+            throw new Exception(APIConfig::VALID_MASTER_SECRET);
+        }
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$master_secret);
         self::baseParamCheck($data);
         switch ($data["channel"]) {
             case "WX_REDPACK":
                 if (!isset($data['redpack_info'])) {
-                    throw new Exception(NEED_PARAM . 'redpack_info');
+                    throw new Exception(APIConfig::NEED_PARAM . 'redpack_info');
                 }
                 break;
             case "WX_TRANSFER":
@@ -456,12 +594,12 @@ class BCRESTApi {
 
                 foreach($aliRequireNames as $v) {
                     if (!isset($data[$v])) {
-                        throw new Exception(NEED_PARAM . $v);
+                        throw new Exception(APIConfig::NEED_PARAM . $v);
                     }
                 }
                 break;
             default:
-                throw new Exception(NEED_VALID_PARAM . "channel = ALI_TRANSFER | WX_TRANSFER | WX_REDPACK");
+                throw new Exception(APIConfig::NEED_VALID_PARAM . "channel = ALI_TRANSFER | WX_TRANSFER | WX_REDPACK");
                 break;
         }
 
@@ -473,56 +611,66 @@ class BCRESTApi {
 
         foreach($requiedNames as $v) {
             if (!isset($data[$v])) {
-                throw new Exception(NEED_PARAM . $v);
+                throw new Exception(APIConfig::NEED_PARAM . $v);
             }
         }
 
-        return BCRESTUtil::post(URI_TRANSFER, $data, 30, false);
+        return BCRESTUtil::post(APIConfig::URI_TRANSFER, $data, 30, false);
     }
 
     //批量打款 - 支付宝
     static final public function transfers(array $data) {
+        if(empty(self::$master_secret)){
+            throw new Exception(APIConfig::VALID_MASTER_SECRET);
+        }
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$master_secret);
         self::baseParamCheck($data);
         switch ($data["channel"]) {
             case "ALI":
                 break;
             default:
-                throw new Exception(NEED_VALID_PARAM . "channel only ALI");
+                throw new Exception(APIConfig::NEED_VALID_PARAM . "channel only ALI");
                 break;
         }
 
         if (!isset($data["batch_no"])) {
-            throw new Exception(NEED_PARAM . "batch_no");
+            throw new Exception(APIConfig::NEED_PARAM . "batch_no");
         }
 
         if (!isset($data["account_name"])) {
-            throw new Exception(NEED_PARAM . "account_name");
+            throw new Exception(APIConfig::NEED_PARAM . "account_name");
         }
 
         if (!isset($data["transfer_data"])) {
-            throw new Exception(NEED_PARAM . "transfer_data");
+            throw new Exception(APIConfig::NEED_PARAM . "transfer_data");
         }
 
         if (!is_array($data["transfer_data"])) {
-            throw new Exception(NEED_VALID_PARAM . "transfer_data(array)");
+            throw new Exception(APIConfig::NEED_VALID_PARAM . "transfer_data(array)");
         }
 
-        return BCRESTUtil::post(URI_TRANSFERS, $data, 30, false);
+        return BCRESTUtil::post(APIConfig::URI_TRANSFERS, $data, 30, false);
     }
 
     //BC企业打款 - 支持bank
     static final public function bc_transfer_banks($data) {
         if (!isset($data["type"])) {
-            throw new Exception(NEED_PARAM . "type");
+            throw new Exception(APIConfig::NEED_PARAM . "type");
         }
 
-        if(!in_array($data['type'], array('P_DE', 'P_CR', 'C'))) throw new Exception(NEED_VALID_PARAM . 'type(P_DE, P_CR, C)');
+        if(!in_array($data['type'], array('P_DE', 'P_CR', 'C'))) throw new Exception(APIConfig::NEED_VALID_PARAM . 'type(P_DE, P_CR, C)');
 
-        return BCRESTUtil::get(URL_BC_TRANSFER_BANKS, $data, 30, false);
+        return BCRESTUtil::get(APIConfig::URI_BC_TRANSFER_BANKS, $data, 30, false);
     }
 
     //BC企业打款 - 银行卡
     static final public function bc_transfer(array $data) {
+        if(empty(self::$master_secret)){
+            throw new Exception(APIConfig::VALID_MASTER_SECRET);
+        }
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$master_secret);
         self::baseParamCheck($data);
         $params = array(
             'total_fee', 'bill_no', 'title', 'trade_source', 'bank_fullname',
@@ -530,24 +678,26 @@ class BCRESTApi {
         );
         foreach ($params as $v) {
             if (!isset($data[$v])) {
-                throw new Exception(NEED_PARAM . $v);
+                throw new Exception(APIConfig::NEED_PARAM . $v);
             }
         }
-        if(!in_array($data['card_type'], array('DE', 'CR'))) throw new Exception(NEED_VALID_PARAM . 'card_type(DE, CR)');
-        if(!in_array($data['account_type'], array('P', 'C'))) throw new Exception(NEED_VALID_PARAM . 'account_type(P, C)');
+        if(!in_array($data['card_type'], array('DE', 'CR'))) throw new Exception(APIConfig::NEED_VALID_PARAM . 'card_type(DE, CR)');
+        if(!in_array($data['account_type'], array('P', 'C'))) throw new Exception(APIConfig::NEED_VALID_PARAM . 'account_type(P, C)');
 
-        return BCRESTUtil::post(URI_BC_TRANSFER, $data, 30, false);
+        return BCRESTUtil::post(APIConfig::URI_BC_TRANSFER, $data, 30, false);
     }
 
 
     static final public function offline_bill(array $data) {
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
         self::baseParamCheck($data);
         if (isset($data["channel"])) {
             switch ($data["channel"]) {
                 case "WX_SCAN":
                 case "ALI_SCAN":
                     if (!isset($data['method']) && !isset($data['auth_code'])) {
-                        throw new Exception(NEED_PARAM . "auth_code");
+                        throw new Exception(APIConfig::NEED_PARAM . "auth_code");
                     }
                     break;
                 case "WX_NATIVE":
@@ -555,39 +705,41 @@ class BCRESTApi {
                 case "SCAN":
                     break;
                 default:
-                    throw new Exception(NEED_VALID_PARAM . "channel = WX_NATIVE | WX_SCAN | ALI_OFFLINE_QRCODE | ALI_SCAN | SCAN");
+                    throw new Exception(APIConfig::NEED_VALID_PARAM . "channel = WX_NATIVE | WX_SCAN | ALI_OFFLINE_QRCODE | ALI_SCAN | SCAN");
                     break;
             }
         }
 
         if (!isset($data["bill_no"])) {
-            throw new Exception(NEED_PARAM . "bill_no");
+            throw new Exception(APIConfig::NEED_PARAM . "bill_no");
         }
         if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
-            throw new Exception(NEED_VALID_PARAM . "bill_no");
+            throw new Exception(APIConfig::NEED_VALID_PARAM . "bill_no");
         }
 
         if (!isset($data['method'])) {
             if (!isset($data["channel"])) {
-                throw new Exception(NEED_PARAM . "channel");
+                throw new Exception(APIConfig::NEED_PARAM . "channel");
             }
             if (!isset($data["total_fee"])) {
-                throw new Exception(NEED_PARAM . "total_fee");
+                throw new Exception(APIConfig::NEED_PARAM . "total_fee");
             } else if(!is_int($data["total_fee"]) || 1>$data["total_fee"]) {
-                throw new Exception(NEED_VALID_PARAM . "total_fee");
+                throw new Exception(APIConfig::NEED_VALID_PARAM . "total_fee");
             }
 
             if (!isset($data["title"])) {
-                throw new Exception(NEED_PARAM . "title");
+                throw new Exception(APIConfig::NEED_PARAM . "title");
             }
-            return BCRESTUtil::post(URI_OFFLINE_BILL, $data, 30, false);
+            return BCRESTUtil::post(APIConfig::URI_OFFLINE_BILL, $data, 30, false);
         }
         $bill_no = $data["bill_no"];
         unset($data["bill_no"]);
-        return BCRESTUtil::post(URI_OFFLINE_BILL.'/'.$bill_no, $data, 30, false);
+        return BCRESTUtil::post(APIConfig::URI_OFFLINE_BILL.'/'.$bill_no, $data, 30, false);
     }
 
     static final public function offline_bill_status(array $data) {
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
         self::baseParamCheck($data);
 
         if (isset($data["channel"])) {
@@ -598,21 +750,26 @@ class BCRESTApi {
                 case "ALI_OFFLINE_QRCODE":
                     break;
                 default:
-                    throw new Exception(NEED_VALID_PARAM . "channel = WX_NATIVE | WX_SCAN | ALI_OFFLINE_QRCODE | ALI_SCAN");
+                    throw new Exception(APIConfig::NEED_VALID_PARAM . "channel = WX_NATIVE | WX_SCAN | ALI_OFFLINE_QRCODE | ALI_SCAN");
                     break;
             }
         }
 
         if (!isset($data["bill_no"])) {
-            throw new Exception(NEED_PARAM . "bill_no");
+            throw new Exception(APIConfig::NEED_PARAM . "bill_no");
         }
         if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
-            throw new Exception(NEED_VALID_PARAM . "bill_no");
+            throw new Exception(APIConfig::NEED_VALID_PARAM . "bill_no");
         }
-        return BCRESTUtil::post(URI_OFFLINE_BILL_STATUS, $data, 30, false);
+        return BCRESTUtil::post(APIConfig::URI_OFFLINE_BILL_STATUS, $data, 30, false);
     }
 
     static final public function offline_refund(array $data){
+        if(empty(self::$master_secret)){
+            throw new Exception(APIConfig::VALID_MASTER_SECRET);
+        }
+        $data["app_id"] = self::$app_id;
+        $data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$master_secret);
         self::baseParamCheck($data);
         if (isset($data['channel'])) {
             switch ($data["channel"]) {
@@ -620,32 +777,32 @@ class BCRESTApi {
                 case "WX":
                     break;
                 default:
-                    throw new Exception(NEED_VALID_PARAM . "channel = ALI | WX");
+                    throw new Exception(APIConfig::NEED_VALID_PARAM . "channel = ALI | WX");
                     break;
             }
         }
 
         if (!isset($data["refund_fee"])) {
-            throw new Exception(NEED_PARAM . "refund_fee");
+            throw new Exception(APIConfig::NEED_PARAM . "refund_fee");
         } else if(!is_int($data["refund_fee"]) || 1>$data["refund_fee"]) {
-            throw new Exception(NEED_VALID_PARAM . "refund_fee");
+            throw new Exception(APIConfig::NEED_VALID_PARAM . "refund_fee");
         }
 
         if (!isset($data["bill_no"])) {
-            throw new Exception(NEED_PARAM . "bill_no");
+            throw new Exception(APIConfig::NEED_PARAM . "bill_no");
         }
         if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
-            throw new Exception(NEED_VALID_PARAM . "bill_no");
+            throw new Exception(APIConfig::NEED_VALID_PARAM . "bill_no");
         }
 
         if (!isset($data["refund_no"])) {
-            throw new Exception(NEED_PARAM . "refund_no");
+            throw new Exception(APIConfig::NEED_PARAM . "refund_no");
         }
         if (!preg_match('/^\d{8}[0-9A-Za-z]{3,24}$/', $data["refund_no"]) || preg_match('/^\d{8}0{3}/', $data["refund_no"])) {
-            throw new Exception(NEED_VALID_PARAM . "refund_no");
+            throw new Exception(APIConfig::NEED_VALID_PARAM . "refund_no");
         }
 
-        return BCRESTUtil::post(URI_OFFLINE_REFUND, $data, 30, false);
+        return BCRESTUtil::post(APIConfig::URI_OFFLINE_REFUND, $data, 30, false);
     }
 
 
@@ -686,9 +843,10 @@ class BCRESTApi {
                 case "BC" :
                 case "BC_GATEWAY" :
                 case "BC_EXPRESS" :
+                case "BC_APP" :
                     break;
                 default:
-                    throw new Exception(NEED_VALID_PARAM . "channel");
+                    throw new Exception(APIConfig::NEED_VALID_PARAM . "channel");
                     break;
             }
         }

--- a/sdk/src/rest/api.php
+++ b/sdk/src/rest/api.php
@@ -7,61 +7,104 @@ namespace beecloud\rest;
 
 class api {
 
-    static final private function baseParamCheck(array $data) {
-        if (!isset($data["app_id"])) {
-            throw new \Exception(NEED_PARAM . "app_id");
-        }
+	//BeeCloud main pay params
+	public static $app_id;
+	public static $app_secret;
+	public static $master_secret;
+	public static $test_secret;
 
-        if (!isset($data["timestamp"])) {
-            throw new \Exception(NEED_PARAM . "timestamp");
-        }
+	//Test Model,只提供下单和支付订单查询的Sandbox模式
+	public static $mode = false;
 
-        if (!isset($data["app_sign"])) {
-            throw new \Exception(NEED_PARAM . "app_sign");
-        }
-    }
+	static function getMode(){
+		return self::$mode;
+	}
 
-    static final protected function post($api, $data, $timeout, $returnArray) {
-        $url = \beecloud\rest\network::getApiUrl() . $api;
-        $httpResultStr = \beecloud\rest\network::request($url, "post", $data, $timeout);
-        $result = json_decode($httpResultStr, !$returnArray ? false : true);
-        if (!$result) {
-            throw new \Exception(UNEXPECTED_RESULT . $httpResultStr);
-        }
-        return $result;
-    }
+	static function setMode($flag = false){
+		self::$mode = $flag;
+	}
 
-    static final protected function get($api, $data, $timeout, $returnArray) {
-        $url = \beecloud\rest\network::getApiUrl() . $api;
-        $httpResultStr = \beecloud\rest\network::request($url, "get", $data, $timeout);
-        $result = json_decode($httpResultStr,!$returnArray ? false : true);
-        if (!$result) {
-            throw new \Exception(UNEXPECTED_RESULT . $httpResultStr);
-        }
-        return $result;
-    }
-    
-    static final protected function put($api, $data, $timeout, $returnArray) {
-        $url = \beecloud\rest\network::getApiUrl() . $api;
-        $httpResultStr = \beecloud\rest\network::request($url, "put", $data, $timeout);
-        $result = json_decode($httpResultStr,!$returnArray ? false : true);
-        if (!$result) {
-            throw new \Exception(UNEXPECTED_RESULT . $httpResultStr);
-        }
-        return $result;
-    }
+	/*
+	 * @param $app_id beecloud平台的APP ID
+	 * @param $app_secret  beecloud平台的APP SECRET
+	 * @param $master_secret  beecloud平台的MASTER SECRET
+	 * @param $test_secret  beecloud平台的TEST SECRET
+	 */
+	static function registerApp($app_id, $app_secret, $master_secret, $test_secret = ''){
+		if(empty($app_id) || empty($app_secret) || empty($master_secret)){
+			throw new \Exception(\beecloud\rest\config::VALID_BC_PARAM);
+		}
+		self::$app_id = $app_id;
+		self::$app_secret = $app_secret;
+		self::$master_secret = $master_secret;
+		self::$test_secret = $test_secret;
+	}
 
-    /**
-     * @param array $data
-     * @param $method post(default),get
-     * @return mixed
-     * @throws \Exception
-     */
-    static final public function bill(array $data, $method = 'post') {
-        //param validation
-        self::baseParamCheck($data);
+	static function get_sign($app_id, $timestamp, $secret){
+		if(empty($app_id) || empty($timestamp) || empty($secret)){
+			throw new \Exception(\beecloud\rest\config::VALID_SIGN_PARAM);
+		}
+		return md5($app_id.$timestamp.$secret);
+	}
+
+
+	static final private function baseParamCheck(array $data) {
+		if (!isset($data["app_id"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "app_id");
+		}
+
+		if (!isset($data["timestamp"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "timestamp");
+		}
+
+		if (!isset($data["app_sign"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "app_sign");
+		}
+	}
+
+	static final public function post($api, $data, $timeout, $returnArray) {
+		$url = \beecloud\rest\network::getApiUrl() . $api;
+		$httpResultStr = \beecloud\rest\network::request($url, "post", $data, $timeout);
+		$result = json_decode($httpResultStr, !$returnArray ? false : true);
+		if (!$result) {
+			throw new \Exception(\beecloud\rest\config::UNEXPECTED_RESULT . $httpResultStr);
+		}
+		return $result;
+	}
+
+	static final public function get($api, $data, $timeout, $returnArray) {
+		$url = \beecloud\rest\network::getApiUrl() . $api;
+		$httpResultStr = \beecloud\rest\network::request($url, "get", $data, $timeout);
+		$result = json_decode($httpResultStr,!$returnArray ? false : true);
+		if (!$result) {
+			throw new \Exception(\beecloud\rest\config::UNEXPECTED_RESULT . $httpResultStr);
+		}
+		return $result;
+	}
+
+	static final public function put($api, $data, $timeout, $returnArray) {
+		$url = \beecloud\rest\network::getApiUrl() . $api;
+		$httpResultStr = \beecloud\rest\network::request($url, "put", $data, $timeout);
+		$result = json_decode($httpResultStr,!$returnArray ? false : true);
+		if (!$result) {
+			throw new \Exception(\beecloud\rest\config::UNEXPECTED_RESULT . $httpResultStr);
+		}
+		return $result;
+	}
+
+	/**
+	 * @param array $data
+	 * @param $method post(default),get
+	 * @return mixed
+	 * @throws \Exception
+	 */
+	static final public function bill(array $data, $method = 'post') {
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$mode ? self::$test_secret : self::$app_secret);
+		//param validation
+		self::baseParamCheck($data);
 		self::channelCheck($data);
-        if (isset($data["channel"])) {
+		if (isset($data["channel"])) {
 			switch($data["channel"]){
 				case 'ALI_WEB':
 				case 'ALI_QRCODE':
@@ -70,534 +113,555 @@ class api {
 				case 'JD_WEB':
 				case 'JD_B2B':
 				case "BC_GATEWAY":
-				//case "BC_EXPRESS":
+					//case "BC_EXPRESS":
 					if (!isset($data["return_url"])) {
-						throw new \Exception(NEED_RETURN_URL);
+						throw new \Exception(\beecloud\rest\config::NEED_RETURN_URL);
 					}
 					break;
 			}
 
-	        switch ($data["channel"]) {
-	            case "WX_JSAPI":
-	                if (!isset($data["openid"])) {
-	                    throw new \Exception(NEED_WX_JSAPI_OPENID);
-	                }
-	                break;
-	        	case "ALI_QRCODE":
-	        		if (!isset($data["qr_pay_mode"])) {
-	                    throw new \Exception(NEED_QR_PAY_MODE);
-	                }
-	            	break;
-				case "JD_B2B":
-					if (!in_array($data["bank_code"], unserialize(BANK_CODE))) {
-						throw new \Exception(NEED_VALID_PARAM.'bank_code');
+			switch ($data["channel"]) {
+				case "WX_JSAPI":
+					if (!isset($data["openid"])) {
+						throw new \Exception(\beecloud\rest\config::NEED_WX_JSAPI_OPENID);
 					}
 					break;
-	            case "YEE_WAP":
-	                if (!isset($data["identity_id"])) {
-	                    throw new \Exception(NEED_IDENTITY_ID);
-	                }
-	                break;
-	            case "YEE_NOBANKCARD":
-	        		if (!isset($data["cardno"])) {
-	                    throw new \Exception(NEED_CARDNO);
-	                }
-	        		if (!isset($data["cardpwd"])) {
-	                    throw new \Exception(NEED_CARDPWD);
-	                }
-	        		if (!isset($data["frqid"])) {
-	                    throw new \Exception(NEED_FRQID);
-	                }
-	            	break;
-	            case "JD_WEB":
-	            case "JD_WAP":
-	                if (isset($data["bill_timeout"])) {
-	                    throw new \Exception(BILL_TIMEOUT_ERROR);
-	                }
-	                break;
-	            case "KUAIQIAN_WAP":
-	            case "KUAIQIAN_WEB":
+				case "ALI_QRCODE":
+					if (!isset($data["qr_pay_mode"])) {
+						throw new \Exception(\beecloud\rest\config::NEED_QR_PAY_MODE);
+					}
+					break;
+				case "JD_B2B":
+					if (!in_array($data["bank_code"], \beecloud\rest\config::get_bank_code())) {
+						throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM.'bank_code');
+					}
+					break;
+				case "YEE_WAP":
+					if (!isset($data["identity_id"])) {
+						throw new \Exception(\beecloud\rest\config::NEED_IDENTITY_ID);
+					}
+					break;
+				case "YEE_NOBANKCARD":
+					if (!isset($data["cardno"])) {
+						throw new \Exception(\beecloud\rest\config::NEED_CARDNO);
+					}
+					if (!isset($data["cardpwd"])) {
+						throw new \Exception(\beecloud\rest\config::NEED_CARDPWD);
+					}
+					if (!isset($data["frqid"])) {
+						throw new \Exception(\beecloud\rest\config::NEED_FRQID);
+					}
+					break;
+				case "JD_WEB":
+				case "JD_WAP":
+					if (isset($data["bill_timeout"])) {
+						throw new \Exception(\beecloud\rest\config::BILL_TIMEOUT_ERROR);
+					}
+					break;
+				case "KUAIQIAN_WAP":
+				case "KUAIQIAN_WEB":
 //	                if (isset($data["bill_timeout"])) {
 //	                    throw new \Exception(BILL_TIMEOUT_ERROR);
 //	                }
 //	                break;
-	            case "BC_GATEWAY":
-                    if (!isset($data["bank"])) {
-                        throw new \Exception(NEED_PARAM.'bank');
-                    }
-					if (!in_array($data["bank"], unserialize(BANK))) {
-						throw new \Exception(NEED_VALID_PARAM.'bank');
+				case "BC_GATEWAY":
+					if (!isset($data["bank"])) {
+						throw new \Exception(\beecloud\rest\config::NEED_PARAM.'bank');
 					}
-                    break;
-				case "BC_EXPRESS" :
-					if ($data["total_fee"] < 100 || !is_int($data["total_fee"])) {
-						throw new \Exception(NEED_TOTAL_FEE);
+					if (!in_array($data["bank"], \beecloud\rest\config::get_bank())) {
+						throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM.'bank');
 					}
 					break;
-	        }
-    	}
-        
-        switch ($method) {
-        	case 'get'://支付订单查询
-        		if (!isset($data["id"])) {
-		            throw new \Exception(NEED_PARAM . "id");
-		        }
-		        $order_id = $data["id"];
-		        unset($data["id"]);
-		        return self::get(URI_BILL.'/'.$order_id, $data, 30, false);
-        		break;
-        	case 'post': // 支付
-        		if (!isset($data["channel"])) {
-        			throw new \Exception(NEED_PARAM . "channel");
-        		}
-        		if (!isset($data["total_fee"])) {
-		            throw new \Exception(NEED_PARAM . "total_fee");
-		        } else if(!is_int($data["total_fee"]) || 1>$data["total_fee"]) {
-		            throw new \Exception(NEED_VALID_PARAM . "total_fee");
-		        }
-		
-		        if (!isset($data["bill_no"])) {
-		            throw new \Exception(NEED_PARAM . "bill_no");
-		        } 
-		    	if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
-		        	throw new \Exception(NEED_VALID_PARAM . "bill_no");
-		        }
-		
-		        if (!isset($data["title"])) {
-		            throw new \Exception(NEED_PARAM . "title");
-		        }
-				return self::post(URI_BILL, $data, 30, false);
-        		break;
+				case "BC_EXPRESS" :
+					if ($data["total_fee"] < 100 || !is_int($data["total_fee"])) {
+						throw new \Exception(\beecloud\rest\config::NEED_TOTAL_FEE);
+					}
+					break;
+			}
+		}
+
+		$url = \beecloud\rest\api::getMode() ? \beecloud\rest\config::URI_TEST_BILL : \beecloud\rest\config::URI_BILL;
+		switch ($method) {
+			case 'get'://支付订单查询
+				if (!isset($data["id"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "id");
+				}
+				$order_id = $data["id"];
+				unset($data["id"]);
+				return self::get($url.'/'.$order_id, $data, 30, false);
+				break;
+			case 'post': // 支付
+				if (!isset($data["channel"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "channel");
+				}
+				if (!isset($data["total_fee"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "total_fee");
+				} else if(!is_int($data["total_fee"]) || 1>$data["total_fee"]) {
+					throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "total_fee");
+				}
+
+				if (!isset($data["bill_no"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "bill_no");
+				}
+				if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "bill_no");
+				}
+
+				if (!isset($data["title"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "title");
+				}
+				return self::post($url, $data, 30, false);
+				break;
 			default :
 				exit('No this method');
 				break;
-        }
-    }
-    
-	static final public function bills(array $data) {
-        //required param existence check
-        self::baseParamCheck($data);
- 		self::channelCheck($data);
-
-        //param validation
-        return self::get(URI_BILLS, $data, 30, false);
-    }
-    
-    
-    static final public function bills_count(array $data){
-    	self::baseParamCheck($data);
-    	self::channelCheck($data);
-    	
-    	if (isset($data["bill_no"]) && !preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
-        	throw new \Exception(NEED_VALID_PARAM . "bill_no");
 		}
-    	return self::get(URI_BILLS_COUNT, $data, 30, false);
-    }
+	}
 
-    static final public function refund(array $data, $method = 'post') {
-        //param validation
-        self::baseParamCheck($data);
+	static final public function bills(array $data) {
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$mode ? self::$test_secret : self::$app_secret);
+		//required param existence check
+		self::baseParamCheck($data);
+		self::channelCheck($data);
 
-        if (isset($data["channel"])) {
-            switch ($data["channel"]) {
-                case "ALI":
-                case "UN":
-                case "WX":
-                case "JD":
-                case "KUAIQIAN":
-                case "YEE":
-                case "BD":
-                case "BC":
-                    break;
-                default:
-                    throw new \Exception(NEED_VALID_PARAM . "channel");
-                    break;
-            }
-        }
+		$url = \beecloud\rest\api::getMode() ? \beecloud\rest\config::URI_TEST_BILLS : \beecloud\rest\config::URI_BILLS;
+		//param validation
+		return self::get($url, $data, 30, false);
+	}
 
-        switch ($method){
-        	case 'put': //预退款批量审核
-        		if (!isset($data["channel"])) {
-		            throw new \Exception(NEED_PARAM . "channel");
-		        }
-        		if (!isset($data["ids"])) {
-		            throw new \Exception(NEED_PARAM . "ids");
-		        }
-		        if (!is_array($data["ids"])) {
-		            throw new \Exception(NEED_VALID_PARAM . "ids(array)");
-		        }
-        		if (!isset($data["agree"])) {
-		            throw new \Exception(NEED_PARAM . "agree");
-		        }
-		        return self::put(URI_REFUND, $data, 30, false);
-        		break;
-        	case 'get'://退款订单查询
-        		if (!isset($data["id"])) {
-		            throw new \Exception(NEED_PARAM . "id");
-		        }
-		        $order_id = $data["id"];
-		        unset($data["id"]);
-		        return self::get(URI_REFUND.'/'.$order_id, $data, 30, false);
-        		break;
-        	case 'post': //退款
-        	default :
-        		if (!isset($data["bill_no"])) {
-					throw new \Exception(NEED_PARAM . "bill_no");
+
+	static final public function bills_count(array $data){
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$mode ? self::$test_secret : self::$app_secret);
+		self::baseParamCheck($data);
+		self::channelCheck($data);
+
+		if (isset($data["bill_no"]) && !preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "bill_no");
+		}
+
+		$url = \beecloud\rest\api::getMode() ? \beecloud\rest\config::URI_TEST_BILLS_COUNT : \beecloud\rest\config::URI_BILLS_COUNT;
+		return self::get($url, $data, 30, false);
+	}
+
+	static final public function refund(array $data, $method = 'post') {
+		if(empty(self::$master_secret)){
+			throw new \Exception(\beecloud\rest\config::VALID_MASTER_SECRET);
+		}
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], $method == 'get' ? self::$app_secret : self::$master_secret);
+		//param validation
+		self::baseParamCheck($data);
+
+		if (isset($data["channel"])) {
+			switch ($data["channel"]) {
+				case "ALI":
+				case "UN":
+				case "WX":
+				case "JD":
+				case "KUAIQIAN":
+				case "YEE":
+				case "BD":
+				case "BC":
+					break;
+				default:
+					throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "channel");
+					break;
+			}
+		}
+
+		switch ($method){
+			case 'put': //预退款批量审核
+				if (!isset($data["channel"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "channel");
 				}
-		    	if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
-		        	throw new \Exception(NEED_VALID_PARAM . "bill_no");
-		        }
-		        
-		    	if (!isset($data["refund_no"])) {
-		            throw new \Exception(NEED_PARAM . "refund_no");
-		        }
-		        if (!preg_match('/^\d{8}[0-9A-Za-z]{3,24}$/', $data["refund_no"]) || preg_match('/^\d{8}0{3}/', $data["refund_no"])) {
-		        	throw new \Exception(NEED_VALID_PARAM . "refund_no");
-		        }
-		        
-		    	if(!is_int($data["refund_fee"]) || 1>$data["refund_fee"]) {
-		            throw new \Exception(NEED_VALID_PARAM . "refund_fee");
-		        }
-		        return self::post(URI_REFUND, $data, 30, false);
-        		break;
-        }
-    }
+				if (!isset($data["ids"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "ids");
+				}
+				if (!is_array($data["ids"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "ids(array)");
+				}
+				if (!isset($data["agree"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "agree");
+				}
+				return self::put(\beecloud\rest\config::URI_REFUND, $data, 30, false);
+				break;
+			case 'get'://退款订单查询
+				if (!isset($data["id"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "id");
+				}
+				$order_id = $data["id"];
+				unset($data["id"]);
+				return self::get(\beecloud\rest\config::URI_REFUND.'/'.$order_id, $data, 30, false);
+				break;
+			case 'post': //退款
+			default :
+				if (!isset($data["bill_no"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "bill_no");
+				}
+				if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "bill_no");
+				}
+
+				if (!isset($data["refund_no"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "refund_no");
+				}
+				if (!preg_match('/^\d{8}[0-9A-Za-z]{3,24}$/', $data["refund_no"]) || preg_match('/^\d{8}0{3}/', $data["refund_no"])) {
+					throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "refund_no");
+				}
+
+				if(!is_int($data["refund_fee"]) || 1>$data["refund_fee"]) {
+					throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "refund_fee");
+				}
+				return self::post(\beecloud\rest\config::URI_REFUND, $data, 30, false);
+				break;
+		}
+	}
 
 
-    static final public function refunds(array $data) {
-        //required param existence check
-        self::baseParamCheck($data);
-        self::channelCheck($data);
-        //param validation
-        return self::get(URI_REFUNDS, $data, 30, false);
-    }
-    
+	static final public function refunds(array $data) {
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
+		//required param existence check
+		self::baseParamCheck($data);
+		self::channelCheck($data);
+		//param validation
+		return self::get(\beecloud\rest\config::URI_REFUNDS, $data, 30, false);
+	}
+
 	static final public function refunds_count(array $data) {
-        //required param existence check
-        self::baseParamCheck($data);
-        self::channelCheck($data);
-        //param validation
-        return self::get(URI_REFUNDS_COUNT, $data, 30, false);
-    }
-    
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
+		//required param existence check
+		self::baseParamCheck($data);
+		self::channelCheck($data);
+		//param validation
+		return self::get(\beecloud\rest\config::URI_REFUNDS_COUNT, $data, 30, false);
+	}
 
-    static final public function refundStatus(array $data) {
-        //required param existence check
-        self::baseParamCheck($data);
 
-        switch ($data["channel"]) {
-            case "WX":
-            case "YEE":
-            case "KUAIQIAN":
-            case "BD":
-                break;
-            default:
-                throw new \Exception(NEED_VALID_PARAM . "channel");
-                break;
-        }
+	static final public function refundStatus(array $data) {
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
+		//required param existence check
+		self::baseParamCheck($data);
 
-        if (!isset($data["refund_no"])) {
-            throw new \Exception(NEED_PARAM . "refund_no");
-        }
-        //param validation
-        return self::get(URI_REFUND_STATUS, $data, 30, false);
-    }
-    
-    //单笔打款 - 支付宝/微信红包
-    static final public function transfer(array $data) {
-        self::baseParamCheck($data);
-        switch ($data["channel"]) {
-            case "WX_REDPACK":
-        		if (!isset($data['redpack_info'])) {
-					throw new \Exception(NEED_PARAM . 'redpack_info');
+		switch ($data["channel"]) {
+			case "WX":
+			case "YEE":
+			case "KUAIQIAN":
+			case "BD":
+				break;
+			default:
+				throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "channel");
+				break;
+		}
+
+		if (!isset($data["refund_no"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "refund_no");
+		}
+		//param validation
+		return self::get(\beecloud\rest\config::URI_REFUND_STATUS, $data, 30, false);
+	}
+
+	//单笔打款 - 支付宝/微信红包
+	static final public function transfer(array $data) {
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$master_secret);
+		self::baseParamCheck($data);
+		switch ($data["channel"]) {
+			case "WX_REDPACK":
+				if (!isset($data['redpack_info'])) {
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . 'redpack_info');
 				}
-                break;
-            case "WX_TRANSFER":
-                break;
-            case "ALI_TRANSFER":
-                $aliRequireNames = array(
-                    "channel_user_name",
-                    "account_name"
-                );
+				break;
+			case "WX_TRANSFER":
+				break;
+			case "ALI_TRANSFER":
+				$aliRequireNames = array(
+					"channel_user_name",
+					"account_name"
+				);
 
-                foreach($aliRequireNames as $v) {
-                    if (!isset($data[$v])) {
-                        throw new \Exception(NEED_PARAM . $v);
-                    }
-                }
-                break;
-            default:
-                throw new \Exception(NEED_VALID_PARAM . "channel = ALI_TRANSFER | WX_TRANSFER | WX_REDPACK");
-                break;
-        }
+				foreach($aliRequireNames as $v) {
+					if (!isset($data[$v])) {
+						throw new \Exception(\beecloud\rest\config::NEED_PARAM . $v);
+					}
+				}
+				break;
+			default:
+				throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "channel = ALI_TRANSFER | WX_TRANSFER | WX_REDPACK");
+				break;
+		}
 
-        $requiedNames = array("transfer_no",
-            "total_fee",
-            "desc",
-            "channel_user_id"
-            );
+		$requiedNames = array("transfer_no",
+			"total_fee",
+			"desc",
+			"channel_user_id"
+		);
 
-        foreach($requiedNames as $v) {
-            if (!isset($data[$v])) {
-                throw new \Exception(NEED_PARAM . $v);
-            }
-        }
+		foreach($requiedNames as $v) {
+			if (!isset($data[$v])) {
+				throw new \Exception(\beecloud\rest\config::NEED_PARAM . $v);
+			}
+		}
 
-        return self::post(URI_TRANSFER, $data, 30, false);
-    }
+		return self::post(\beecloud\rest\config::URI_TRANSFER, $data, 30, false);
+	}
 
-    //批量打款 - 支付宝
-    static final public function transfers(array $data) {
-        self::baseParamCheck($data);
-        switch ($data["channel"]) {
-            case "ALI":
-                break;
-            default:
-                throw new \Exception(NEED_VALID_PARAM . "channel only ALI");
-                break;
-        }
+	//批量打款 - 支付宝
+	static final public function transfers(array $data) {
+		if(empty(self::$master_secret)){
+			throw new \Exception(\beecloud\rest\config::VALID_MASTER_SECRET);
+		}
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$master_secret);
+		self::baseParamCheck($data);
+		switch ($data["channel"]) {
+			case "ALI":
+				break;
+			default:
+				throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "channel only ALI");
+				break;
+		}
 
-        if (!isset($data["batch_no"])) {
-            throw new \Exception(NEED_PARAM . "batch_no");
-        }
+		if (!isset($data["batch_no"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "batch_no");
+		}
 
-        if (!isset($data["account_name"])) {
-            throw new \Exception(NEED_PARAM . "account_name");
-        }
+		if (!isset($data["account_name"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "account_name");
+		}
 
-        if (!isset($data["transfer_data"])) {
-            throw new \Exception(NEED_PARAM . "transfer_data");
-        }
+		if (!isset($data["transfer_data"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "transfer_data");
+		}
 
-        if (!is_array($data["transfer_data"])) {
-            throw new \Exception(NEED_VALID_PARAM . "transfer_data(array)");
-        }
+		if (!is_array($data["transfer_data"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "transfer_data(array)");
+		}
 
-        return self::post(URI_TRANSFERS, $data, 30, false);
-    }
+		return self::post(\beecloud\rest\config::URI_TRANSFERS, $data, 30, false);
+	}
 
 	//BC企业打款 - 支持bank
 	static final public function bc_transfer_banks($data) {
 		if (!isset($data["type"])) {
-			throw new \Exception(NEED_PARAM . "type");
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "type");
 		}
 
-		if(!in_array($data['type'], array('P_DE', 'P_CR', 'C'))) throw new \Exception(NEED_VALID_PARAM . 'type(P_DE, P_CR, C)');
+		if(!in_array($data['type'], array('P_DE', 'P_CR', 'C'))) throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . 'type(P_DE, P_CR, C)');
 
-		return self::get(URL_BC_TRANSFER_BANKS, $data, 30, false);
+		return self::get(\beecloud\rest\config::URI_BC_TRANSFER_BANKS, $data, 30, false);
 	}
 
-    //BC企业打款 - 银行卡
-    static final public function bc_transfer(array $data) {
-        self::baseParamCheck($data);
-        $params = array(
-        	'total_fee', 'bill_no', 'title', 'trade_source', 'bank_fullname',
-        	'card_type', 'account_type', 'account_no', 'account_name'
-        );
-        foreach ($params as $v) {
-         	if (!isset($data[$v])) {
-                throw new \Exception(NEED_PARAM . $v);
-            }
-        }
-        if(!in_array($data['card_type'], array('DE', 'CR'))) throw new \Exception(NEED_VALID_PARAM . 'card_type(DE, CR)');
-        if(!in_array($data['account_type'], array('P', 'C'))) throw new \Exception(NEED_VALID_PARAM . 'account_type(P, C)');
+	//BC企业打款 - 银行卡
+	static final public function bc_transfer(array $data) {
+		if(empty(self::$master_secret)){
+			throw new \Exception(\beecloud\rest\config::VALID_MASTER_SECRET);
+		}
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$master_secret);
+		self::baseParamCheck($data);
+		$params = array(
+			'total_fee', 'bill_no', 'title', 'trade_source', 'bank_fullname',
+			'card_type', 'account_type', 'account_no', 'account_name'
+		);
+		foreach ($params as $v) {
+			if (!isset($data[$v])) {
+				throw new \Exception(\beecloud\rest\config::NEED_PARAM . $v);
+			}
+		}
+		if(!in_array($data['card_type'], array('DE', 'CR'))) throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . 'card_type(DE, CR)');
+		if(!in_array($data['account_type'], array('P', 'C'))) throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . 'account_type(P, C)');
 
-        return self::post(URI_BC_TRANSFER, $data, 30, false);
-    }
-    
-    
+		return self::post(\beecloud\rest\config::URI_BC_TRANSFER, $data, 30, false);
+	}
+
+
 	static final public function offline_bill(array $data) {
-        self::baseParamCheck($data);
-        if (isset($data["channel"])) {
-	        switch ($data["channel"]) {
-	            case "WX_SCAN":
-	            case "ALI_SCAN":
-	            	if (!isset($data['method']) && !isset($data['auth_code'])) {
-	            		throw new \Exception(NEED_PARAM . "auth_code");
-	            	}
-	            	break;
-	            case "WX_NATIVE":
-	            case "ALI_OFFLINE_QRCODE":
-	            case "SCAN":
-	                break;
-	            default:
-	                throw new \Exception(NEED_VALID_PARAM . "channel = WX_NATIVE | WX_SCAN | ALI_OFFLINE_QRCODE | ALI_SCAN | SCAN");
-	                break;
-	        }
-        }
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
+		self::baseParamCheck($data);
+		if (isset($data["channel"])) {
+			switch ($data["channel"]) {
+				case "WX_SCAN":
+				case "ALI_SCAN":
+					if (!isset($data['method']) && !isset($data['auth_code'])) {
+						throw new \Exception(\beecloud\rest\config::NEED_PARAM . "auth_code");
+					}
+					break;
+				case "WX_NATIVE":
+				case "ALI_OFFLINE_QRCODE":
+				case "SCAN":
+					break;
+				default:
+					throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "channel = WX_NATIVE | WX_SCAN | ALI_OFFLINE_QRCODE | ALI_SCAN | SCAN");
+					break;
+			}
+		}
 
-        if (!isset($data["bill_no"])) {
-            throw new \Exception(NEED_PARAM . "bill_no");
-        }
-        if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
-            throw new \Exception(NEED_VALID_PARAM . "bill_no");
-        }
-        
-        if (!isset($data['method'])) {
+		if (!isset($data["bill_no"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "bill_no");
+		}
+		if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "bill_no");
+		}
+
+		if (!isset($data['method'])) {
 			if (!isset($data["channel"])) {
-				throw new \Exception(NEED_PARAM . "channel");
+				throw new \Exception(\beecloud\rest\config::NEED_PARAM . "channel");
 			}
 			if (!isset($data["total_fee"])) {
-	            throw new \Exception(NEED_PARAM . "total_fee");
-	        } else if(!is_int($data["total_fee"]) || 1>$data["total_fee"]) {
-	            throw new \Exception(NEED_VALID_PARAM . "total_fee");
-	        }
-	
-	        if (!isset($data["title"])) {
-	            throw new \Exception(NEED_PARAM . "title");
-	        }
-        	return self::post(URI_OFFLINE_BILL, $data, 30, false);
-        }
+				throw new \Exception(\beecloud\rest\config::NEED_PARAM . "total_fee");
+			} else if(!is_int($data["total_fee"]) || 1>$data["total_fee"]) {
+				throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "total_fee");
+			}
+
+			if (!isset($data["title"])) {
+				throw new \Exception(\beecloud\rest\config::NEED_PARAM . "title");
+			}
+			return self::post(\beecloud\rest\config::URI_OFFLINE_BILL, $data, 30, false);
+		}
 		$bill_no = $data["bill_no"];
 		unset($data["bill_no"]);
-		return self::post(URI_OFFLINE_BILL.'/'.$bill_no, $data, 30, false);
-    }
-    
+		return self::post(\beecloud\rest\config::URI_OFFLINE_BILL.'/'.$bill_no, $data, 30, false);
+	}
+
 	static final public function offline_bill_status(array $data) {
-        self::baseParamCheck($data);
-        
-        if (isset($data["channel"])) {
-	        switch ($data["channel"]) {
-	            case "WX_SCAN":
-	            case "ALI_SCAN":
-	            case "WX_NATIVE":
-	            case "ALI_OFFLINE_QRCODE":
-	                break;
-	            default:
-	                throw new \Exception(NEED_VALID_PARAM . "channel = WX_NATIVE | WX_SCAN | ALI_OFFLINE_QRCODE | ALI_SCAN");
-	                break;
-	        }
-        }
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$app_secret);
+		self::baseParamCheck($data);
+
+		if (isset($data["channel"])) {
+			switch ($data["channel"]) {
+				case "WX_SCAN":
+				case "ALI_SCAN":
+				case "WX_NATIVE":
+				case "ALI_OFFLINE_QRCODE":
+					break;
+				default:
+					throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "channel = WX_NATIVE | WX_SCAN | ALI_OFFLINE_QRCODE | ALI_SCAN");
+					break;
+			}
+		}
 
 		if (!isset($data["bill_no"])) {
-			throw new \Exception(NEED_PARAM . "bill_no");
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "bill_no");
 		}
-    	if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
-        	throw new \Exception(NEED_VALID_PARAM . "bill_no");
-        }
-        return self::post(URI_OFFLINE_BILL_STATUS, $data, 30, false);
-    }
-    
-    static final public function offline_refund(array $data){
-    	self::baseParamCheck($data);
-        if (isset($data['channel'])) {
-	        switch ($data["channel"]) {
-	            case "ALI":
-	            case "WX":
-	                break;
-	            default:
-	                throw new \Exception(NEED_VALID_PARAM . "channel = ALI | WX");
-	                break;
-	        }
-        }
+		if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "bill_no");
+		}
+		return self::post(\beecloud\rest\config::URI_OFFLINE_BILL_STATUS, $data, 30, false);
+	}
+
+	static final public function offline_refund(array $data){
+		if(empty(self::$master_secret)){
+			throw new \Exception(\beecloud\rest\config::VALID_MASTER_SECRET);
+		}
+		$data["app_id"] = self::$app_id;
+		$data["app_sign"] = self::get_sign($data["app_id"], $data["timestamp"], self::$master_secret);
+		self::baseParamCheck($data);
+		if (isset($data['channel'])) {
+			switch ($data["channel"]) {
+				case "ALI":
+				case "WX":
+					break;
+				default:
+					throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "channel = ALI | WX");
+					break;
+			}
+		}
 
 		if (!isset($data["refund_fee"])) {
-            throw new \Exception(NEED_PARAM . "refund_fee");
-        } else if(!is_int($data["refund_fee"]) || 1>$data["refund_fee"]) {
-            throw new \Exception(NEED_VALID_PARAM . "refund_fee");
-        }
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "refund_fee");
+		} else if(!is_int($data["refund_fee"]) || 1>$data["refund_fee"]) {
+			throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "refund_fee");
+		}
 
 		if (!isset($data["bill_no"])) {
-			throw new \Exception(NEED_PARAM . "bill_no");
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "bill_no");
 		}
-    	if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
-        	throw new \Exception(NEED_VALID_PARAM . "bill_no");
-        }
-        
-    	if (!isset($data["refund_no"])) {
-            throw new \Exception(NEED_PARAM . "refund_no");
-        }
-        if (!preg_match('/^\d{8}[0-9A-Za-z]{3,24}$/', $data["refund_no"]) || preg_match('/^\d{8}0{3}/', $data["refund_no"])) {
-        	throw new \Exception(NEED_VALID_PARAM . "refund_no");
-        }
-        return self::post(URI_OFFLINE_REFUND, $data, 30, false);
-    }
-    
-    
-    static final private function channelCheck($data){
-    	if (isset($data["channel"])) {
-            switch ($data["channel"]) {
-                case "ALI":
-                case "ALI_WEB":
-                case "ALI_WAP":
-                case "ALI_QRCODE":
-                case "ALI_APP":
-                case "ALI_OFFLINE_QRCODE":
-                case "UN":
-                case "UN_WEB":
-                case "UN_APP":
-                case "UN_WAP":
-                case "WX":
-                case "WX_JSAPI":
-                case "WX_NATIVE":
-                case "WX_APP":
-                case "JD":
-                case "JD_WEB":
-                case "JD_WAP":
-                case "JD_B2B":
-                case "YEE":
-                case "YEE_WAP":
-                case "YEE_WEB":
-                case "YEE_NOBANKCARD":
-                case "KUAIQIAN":
-                case "KUAIQIAN_WAP":
-                case "KUAIQIAN_WEB":
-                case "BD":
-                case "BD_WAP":
-                case "BD_WEB":
-                case "PAYPAL":
-                case "PAYPAL_SANDBOX":
-                case "PAYPAL_LIVE":
-                case "BC" :
-                case "BC_GATEWAY" :
-                case "BC_EXPRESS" :
-                    break;
-                default:
-                    throw new \Exception(NEED_VALID_PARAM . "channel");
-                    break;
-            }
-        }
-    }
+		if (!preg_match('/^[0-9A-Za-z]{8,32}$/', $data["bill_no"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "bill_no");
+		}
+
+		if (!isset($data["refund_no"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "refund_no");
+		}
+		if (!preg_match('/^\d{8}[0-9A-Za-z]{3,24}$/', $data["refund_no"]) || preg_match('/^\d{8}0{3}/', $data["refund_no"])) {
+			throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "refund_no");
+		}
+		return self::post(\beecloud\rest\config::URI_OFFLINE_REFUND, $data, 30, false);
+	}
+
+
+	static final private function channelCheck($data){
+		if (isset($data["channel"])) {
+			switch ($data["channel"]) {
+				case "ALI":
+				case "ALI_WEB":
+				case "ALI_WAP":
+				case "ALI_QRCODE":
+				case "ALI_APP":
+				case "ALI_OFFLINE_QRCODE":
+				case "UN":
+				case "UN_WEB":
+				case "UN_APP":
+				case "UN_WAP":
+				case "WX":
+				case "WX_JSAPI":
+				case "WX_NATIVE":
+				case "WX_APP":
+				case "JD":
+				case "JD_WEB":
+				case "JD_WAP":
+				case "JD_B2B":
+				case "YEE":
+				case "YEE_WAP":
+				case "YEE_WEB":
+				case "YEE_NOBANKCARD":
+				case "KUAIQIAN":
+				case "KUAIQIAN_WAP":
+				case "KUAIQIAN_WEB":
+				case "BD":
+				case "BD_WAP":
+				case "BD_WEB":
+				case "PAYPAL":
+				case "PAYPAL_SANDBOX":
+				case "PAYPAL_LIVE":
+				case "BC" :
+				case "BC_GATEWAY" :
+				case "BC_EXPRESS" :
+				case "BC_APP" :
+					break;
+				default:
+					throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "channel");
+					break;
+			}
+		}
+	}
 }
 
 class international {
 
 	static final private function baseParamCheck(array $data) {
 		if (!isset($data["app_id"])) {
-			throw new \Exception(NEED_PARAM . "app_id");
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "app_id");
 		}
 
 		if (!isset($data["timestamp"])) {
-			throw new \Exception(NEED_PARAM . "timestamp");
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "timestamp");
 		}
 
 		if (!isset($data["app_sign"])) {
-			throw new \Exception(NEED_PARAM . "app_sign");
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "app_sign");
 		}
 
 		if (!isset($data["currency"])) {
-			throw new \Exception(NEED_PARAM . "currency");
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "currency");
 		}
-	}
-
-	static final protected function post($api, $data, $timeout, $returnArray) {
-		$url = \beecloud\rest\network::getApiUrl() . $api;
-		$httpResultStr = \beecloud\rest\network::request($url, "post", $data, $timeout);
-		$result = json_decode($httpResultStr, !$returnArray ? false : true);
-		if (!$result) {
-			throw new \Exception(UNEXPECTED_RESULT . $httpResultStr);
-		}
-		return $result;
-	}
-
-	static final protected function get($api, $data, $timeout, $returnArray) {
-		$url = \beecloud\rest\network::getApiUrl() . $api;
-		$httpResultStr = \beecloud\rest\network::request($url, "get", $data, $timeout);
-		$result = json_decode($httpResultStr,!$returnArray ? false : true);
-		if (!$result) {
-			throw new \Exception(UNEXPECTED_RESULT . $httpResultStr);
-		}
-		return $result;
 	}
 
 	/**
@@ -606,68 +670,45 @@ class international {
 	 * @throws \Exception
 	 */
 	static final public function bill(array $data) {
+		$data["app_id"] = \beecloud\rest\api::$app_id;
+		$data["app_sign"] = \beecloud\rest\api::get_sign($data["app_id"], $data["timestamp"], \beecloud\rest\api::$app_secret);
 		//param validation
 		self::baseParamCheck($data);
 
 		switch ($data["channel"]) {
 			case "PAYPAL_PAYPAL":
 				if (!isset($data["return_url"])) {
-					throw new \Exception(NEED_PARAM . "return_url");
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "return_url");
 				}
 				break;
 			case "PAYPAL_CREDITCARD":
 				if (!isset($data["credit_card_info"])) {
-					throw new \Exception(NEED_PARAM . "credit_card_info");
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "credit_card_info");
 				}
 				break;
 			case "PAYPAL_SAVED_CREDITCARD":
 				if (!isset($data["credit_card_id"])) {
-					throw new \Exception(NEED_PARAM . "credit_card_id");
+					throw new \Exception(\beecloud\rest\config::NEED_PARAM . "credit_card_id");
 				}
 				break;
 			default:
-				throw new \Exception(NEED_VALID_PARAM . "channel");
+				throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "channel");
 				break;
 		}
 
 		if (!isset($data["total_fee"])) {
-			throw new \Exception(NEED_PARAM . "total_fee");
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "total_fee");
 		} else if(!is_int($data["total_fee"]) || $data["total_fee"] < 1) {
-			throw new \Exception(NEED_VALID_PARAM . "total_fee");
+			throw new \Exception(\beecloud\rest\config::NEED_VALID_PARAM . "total_fee");
 		}
 
 		if (!isset($data["bill_no"])) {
-			throw new \Exception(NEED_PARAM . "bill_no");
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "bill_no");
 		}
 
 		if (!isset($data["title"])) {
-			throw new \Exception(NEED_PARAM . "title");
+			throw new \Exception(\beecloud\rest\config::NEED_PARAM . "title");
 		}
-
-		return self::post(URI_INTERNATIONAL_BILL, $data, 30, false);
+		return \beecloud\rest\api::post(\beecloud\rest\config::URI_INTERNATIONAL_BILL, $data, 30, false);
 	}
-	/*//TODO:
-    static final public function refund(array $data) {
-        //param validation
-        self::baseParamCheck($data);
-
-        if (isset($data["channel"])) {
-            switch ($data["channel"]) {
-                case "PAYPAL":
-                case "PAYPAL_PAYPAL":
-                case "PAYPAL_CREDITCARD":
-                case "PAYPAL_SAVED_CREDITCARD":
-                    break;
-                default:
-                    throw new \Exception(NEED_VALID_PARAM . "channel");
-                    break;
-            }
-        }
-
-        if (!isset($data["refund_no"])) {
-            throw new \Exception(NEED_PARAM . "refund_no");
-        }
-        // TODO: refund_no validation
-        return self::post(URI_INTERNATIONAL_REFUND, $data, 30, false);
-    }*/
 }

--- a/sdk/src/rest/config.php
+++ b/sdk/src/rest/config.php
@@ -1,66 +1,77 @@
 <?php
-//Test Model,只提供下单和支付订单查询的Sandbox模式
-define('TEST_MODE', false);
 /*
- * bank_code(int 类型) for channel JD_B2B
-9102    中国工商银行      9107    招商银行
-9103    中国农业银行      9108    光大银行
-9104    交通银行         9109    中国银行
-9105    中国建设银行		9110 	 平安银行
-*/
-define('BANK_CODE', serialize(array(9102, 9103, 9104, 9105, 9107, 9108, 9109, 9110)));
+ * global param config
+ */
+namespace beecloud\rest;
 
-/*
- * bank(string 类型) for channel BC_GATEWAY
- * CMB	  招商银行    ICBC	工商银行   CCB   建设银行(暂不支持)
- * BOC	  中国银行    ABC    农业银行   BOCM	交通银行
- * SPDB   浦发银行    GDB	广发银行   CITIC	中信银行
- * CEB	  光大银行    CIB	兴业银行   SDB	平安银行
- * CMBC   民生银行    NBCB   宁波银行   BEA   东亚银行
- * NJCB   南京银行    SRCB   上海农商行 BOB   北京银行
-*/
-define('BANK', serialize(array('CMB', 'ICBC', 'CCB', 'BOC', 'ABC', 'BOCM', 'SPDB', 'GDB',
-	'CITIC', 'CEB', 'CIB', 'SDB', 'CMBC', 'NBCB', 'BEA', 'NJCB', 'SRCB', 'BOB')));
+class config {
 
+	const URI_BILL = '/2/rest/bill'; //支付;支付订单查询(指定id)
+	const URI_TEST_BILL = '/2/rest/sandbox/bill';
+	const URI_BILLS = '/2/rest/bills'; //订单查询
+	const URI_TEST_BILLS = '/2/rest/sandbox/bills';
+	const URI_BILLS_COUNT = '/2/rest/bills/count'; //订单总数查询
+	const URI_TEST_BILLS_COUNT = '/2/rest/sandbox/bills/count';
 
-define('URI_BILL', TEST_MODE ? "/2/rest/sandbox/bill" : "/2/rest/bill"); //支付;支付订单查询(指定id)
-define('URI_BILLS', TEST_MODE ? "/2/rest/sandbox/bills" : "/2/rest/bills"); //订单查询
-define('URI_BILLS_COUNT', TEST_MODE ? "/2/rest/sandbox/bills/count" : "/2/rest/bills/count"); //订单总数查询
+	const URI_REFUND = "/2/rest/refund";		//退款;预退款批量审核;退款订单查询(指定id)
+	const URI_REFUNDS = "/2/rest/refunds";		//退款查询
+	const URI_REFUNDS_COUNT = "/2/rest/refunds/count"; //退款总数查询
+	const URI_REFUND_STATUS = "/2/rest/refund/status"; //退款状态更新
 
-const URI_REFUND = "/2/rest/refund";		//退款;预退款批量审核;退款订单查询(指定id)
-const URI_REFUNDS = "/2/rest/refunds";		//退款查询
-const URI_REFUNDS_COUNT = "/2/rest/refunds/count"; //退款总数查询
-const URI_REFUND_STATUS = "/2/rest/refund/status"; //退款状态更新
+	const URI_TRANSFERS = "/2/rest/transfers"; //批量打款 - 支付宝
+	const URI_TRANSFER = "/2/rest/transfer";  //单笔打款 - 支付宝/微信
+	const URI_BC_TRANSFER_BANKS = '/2/rest/bc_transfer/banks'; //BC企业打款 - 支持银行
+	const URI_BC_TRANSFER = "/2/rest/bc_transfer"; //代付 - 银行卡
 
-const URI_TRANSFERS = "/2/rest/transfers"; //批量打款 - 支付宝
-const URI_TRANSFER = "/2/rest/transfer";  //单笔打款 - 支付宝/微信
-const URL_BC_TRANSFER_BANKS = '/2/rest/bc_transfer/banks'; //BC企业打款 - 支持银行
-const URI_BC_TRANSFER = "/2/rest/bc_transfer"; //代付 - 银行卡
+	const URI_OFFLINE_BILL = '/2/rest/offline/bill'; //线下支付-撤销订单
+	const URI_OFFLINE_BILL_STATUS = '/2/rest/offline/bill/status'; //线下订单状态查询
+	const URI_OFFLINE_REFUND = '/2/rest/offline/refund'; //线下退款
 
-const URI_OFFLINE_BILL = '/2/rest/offline/bill'; //线下支付-撤销订单
-const URI_OFFLINE_BILL_STATUS = '/2/rest/offline/bill/status'; //线下订单状态查询
-const URI_OFFLINE_REFUND = '/2/rest/offline/refund'; //线下退款
-
-const URI_INTERNATIONAL_BILL = "/1/rest/international/bill";
-const URI_INTERNATIONAL_REFUND = "/1/rest/international/refund";
+	const URI_INTERNATIONAL_BILL = "/1/rest/international/bill";
+	const URI_INTERNATIONAL_REFUND = "/1/rest/international/refund";
 
 
-const UNEXPECTED_RESULT = "非预期的返回结果:";
-const NEED_PARAM = "需要必填字段:";
-const NEED_VALID_PARAM = "字段值不合法:";
-const NEED_WX_JSAPI_OPENID = "微信公众号支付(WX_JSAPI) 需要openid字段";
-const NEED_RETURN_URL = "当channel参数为 ALI_WEB 或 ALI_QRCODE 或 UN_WEB 或JD_WAP 或 JD_WEB时 return_url为必填";
-const NEED_IDENTITY_ID = "当channel参数为 YEE_WAP时 identity_id为必填";
-const BILL_TIMEOUT_ERROR = "当channel参数为 JD* 不支持bill_timeout";
-const NEED_QR_PAY_MODE = '当channel参数为 ALI_QRCODE时 qr_pay_mode为必填';
-const NEED_CARDNO = '当channel参数为 YEE_NOBANKCARD时 cardno为必填';
-const NEED_CARDPWD = '当channel参数为 YEE_NOBANKCARD时 cardpwd为必填';
-const NEED_FRQID = '当channel参数为 YEE_NOBANKCARD时 frqid为必填';
-const NEED_TOTAL_FEE = '当channel参数为 BC_EXPRESS时 total_fee单位分,最小金额100分';
-const FIELD_VALUE_EMPTY = '参数值为空,请重新设置';
+	const UNEXPECTED_RESULT = "非预期的返回结果:";
+	const NEED_PARAM = "需要必填字段:";
+	const NEED_VALID_PARAM = "字段值不合法:";
+	const NEED_WX_JSAPI_OPENID = "微信公众号支付(WX_JSAPI) 需要openid字段";
+	const NEED_RETURN_URL = "当channel参数为 ALI_WEB 或 ALI_QRCODE 或 UN_WEB 或JD_WAP 或 JD_WEB时 return_url为必填";
+	const NEED_IDENTITY_ID = "当channel参数为 YEE_WAP时 identity_id为必填";
+	const BILL_TIMEOUT_ERROR = "当channel参数为 JD* 不支持bill_timeout";
+	const NEED_QR_PAY_MODE = '当channel参数为 ALI_QRCODE时 qr_pay_mode为必填';
+	const NEED_CARDNO = '当channel参数为 YEE_NOBANKCARD时 cardno为必填';
+	const NEED_CARDPWD = '当channel参数为 YEE_NOBANKCARD时 cardpwd为必填';
+	const NEED_FRQID = '当channel参数为 YEE_NOBANKCARD时 frqid为必填';
+	const NEED_TOTAL_FEE = '当channel参数为 BC_EXPRESS时 total_fee单位分,最小金额100分';
+	const VALID_BC_PARAM = 'APP ID,APP Secret,Master Secret参数值均不能为空,请重新设置';
+	const VALID_SIGN_PARAM = 'APP ID, timestamp,APP(Master) Secret参数值均不能为空,请设置';
+	const VALID_MASTER_SECRET = 'Master Secret参数值不能为空,请设置';
+	const VALID_APP_SECRET = 'APP Secret参数值不能为空,请设置';
 
-const APP_ID = 'c5d1cba1-5e3f-4ba0-941d-9b0a371fe719';
-const APP_SECRET = '39a7a518-9ac8-4a9e-87bc-7885f33cf18c';
-//test_secret for sandbox
-const TEST_SECRET = '4bfdd244-574d-4bf3-b034-0c751ed34fee';
-const MASTER_SECRET = 'e14ae2db-608c-4f8b-b863-c8c18953eef2';
+	/*
+	 * bank_code(int 类型) for channel JD_B2B
+		9102    中国工商银行      9107    招商银行
+		9103    中国农业银行      9108    光大银行
+		9104    交通银行         9109    中国银行
+		9105    中国建设银行		9110 	 平安银行
+	*/
+	static function get_bank_code(){
+		return array(9102, 9103, 9104, 9105, 9107, 9108, 9109, 9110);
+	}
+
+	/*
+	 * bank(string 类型) for channel BC_GATEWAY
+	 * CMB	  招商银行    ICBC	工商银行   CCB   建设银行(暂不支持)
+	 * BOC	  中国银行    ABC    农业银行   BOCM	交通银行
+	 * SPDB   浦发银行    GDB	广发银行   CITIC	中信银行
+	 * CEB	  光大银行    CIB	兴业银行   SDB	平安银行
+	 * CMBC   民生银行    NBCB   宁波银行   BEA   东亚银行
+	 * NJCB   南京银行    SRCB   上海农商行 BOB   北京银行
+	*/
+	static function get_bank(){
+		return array(
+			'CMB', 'ICBC', 'CCB', 'BOC', 'ABC', 'BOCM', 'SPDB', 'GDB', 'CITIC',
+			'CEB', 'CIB', 'SDB', 'CMBC', 'NBCB', 'BEA', 'NJCB', 'SRCB', 'BOB'
+		);
+	}
+}

--- a/tests/apiTest.php
+++ b/tests/apiTest.php
@@ -13,16 +13,14 @@ class apiTest extends PHPUnit_Framework_TestCase
 		}else{
 			$this->api = new BCRESTApi();
 		}
-		$this->appId = APP_ID;
 		$this->timestamp = time() * 1000;
-		$this->appSign = md5($this->appId . $this->timestamp . APP_SECRET);
+		$this->api->registerApp(APP_ID, APP_SECRET, MASTER_SECRET, TEST_SECRET);
+		$this->api->setMode(false);
 	}
 
 	public function testBill()
     {
-		$data["app_id"] = $this->appId;
 		$data["timestamp"] = $this->timestamp;
-		$data["app_sign"] = $this->appSign;
 		$data["total_fee"] = 1;
 		$data["bill_no"] = "bcdemo" . $data["timestamp"];
 		$data["title"] = "白开水";
@@ -34,9 +32,7 @@ class apiTest extends PHPUnit_Framework_TestCase
 
 	public function testBills()
 	{
-		$data["app_id"] = $this->appId;
 		$data["timestamp"] = $this->timestamp;
-		$data["app_sign"] = $this->appSign;
 		$data["channel"] = "ALI";
 		$data["limit"] = 10;
 		$result = $this->api->bills($data);
@@ -45,9 +41,7 @@ class apiTest extends PHPUnit_Framework_TestCase
 
 	public function testBillCount()
 	{
-		$data["app_id"] = $this->appId;
 		$data["timestamp"] = $this->timestamp;
-		$data["app_sign"] = $this->appSign;
 		$data["channel"] = "ALI";
 		$result = $this->api->bills_count($data);
 		$this->assertTrue(isset($result->count));
@@ -55,9 +49,7 @@ class apiTest extends PHPUnit_Framework_TestCase
 
 	public function testRefund()
 	{
-		$data["app_id"] = $this->appId;
 		$data["timestamp"] = $this->timestamp;
-		$data["app_sign"] = $this->appSign;
 		$data["bill_no"] = 'bcdemo1460634197000';
 		$data["refund_no"] = '201604141460634675000';
 		$data["refund_fee"] = 1;
@@ -68,21 +60,16 @@ class apiTest extends PHPUnit_Framework_TestCase
 
 	public function testRefundStatus()
 	{
-		$data["app_id"] = $this->appId;
 		$data["timestamp"] = $this->timestamp;
-		$data["app_sign"] = $this->appSign;
 		$data["channel"] = "WX";
-		$data["refund_no"] = '201604121460463957000';
+		$data["refund_no"] = '20168888888888888888';
 		$result = $this->api->refundStatus($data);
-		print_r($result);
-		//$this->assertNotEquals('SUCCESS', $result->refund_status);
+		$this->assertEquals('NO_SUCH_REFUND', $result->result_msg);
 	}
 
 	public function testRefunds()
 	{
-		$data["app_id"] = $this->appId;
 		$data["timestamp"] = $this->timestamp;
-		$data["app_sign"] = $this->appSign;
 		$data["channel"] = "ALI";
 		$data["limit"] = 10;
 		$result = $this->api->refunds($data);
@@ -91,34 +78,9 @@ class apiTest extends PHPUnit_Framework_TestCase
 
 	public function testRefundCount()
 	{
-		$data["app_id"] = $this->appId;
 		$data["timestamp"] = $this->timestamp;
-		$data["app_sign"] = $this->appSign;
 		$data["channel"] = "ALI";
 		$result = $this->api->refunds_count($data);
 		$this->assertTrue(isset($result->count));
 	}
-
-	/*public function testOfflineBill(){
-		$data["app_id"] = $this->appId;
-		$data["timestamp"] = $this->timestamp;
-		$data["app_sign"] = $this->appSign;
-		$data["total_fee"] = 1;
-		$data["bill_no"] = "bcdemo" . $data["timestamp"];
-		$data["title"] = "白开水";
-		$data["channel"] = 'ALI_OFFLINE_QRCODE';
-		$data["return_url"] = "http://payservice.beecloud.cn";
-		$result = $this->api->offline_bill($data);
-		$this->assertEquals(0, $result->result_code);
-	}
-
-	public function testOfflineBillStatus(){
-		$data["app_id"] = $this->appId;
-		$data["timestamp"] = $this->timestamp;
-		$data["app_sign"] = $this->appSign;
-		$data["bill_no"] = "bcdemo1460637009000";
-		$data["channel"] = 'ALI_OFFLINE_QRCODE';
-		$result = $this->api->offline_bill_status($data);
-		$this->assertTrue(isset($result->result_code));
-	}*/
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
-require_once("sdk/src/rest/config.php");
+require_once 'demo/config.php';
 if(version_compare(PHP_VERSION, '5.3.0','>')) {
+    require_once("sdk/src/rest/config.php");
     require_once("sdk/src/rest/network.php");
     require_once("sdk/src/rest/api.php");
 } else {


### PR DESCRIPTION
v3.0.0 发布:
1. BeeCloud平台参数配置,原在sdk/src/rest/config.php设置常量,现更改为
  \beecloud\rest\api::registerApp('app id', 'app secret', 'master secret', 'test secret'),
  或者BCRESTApi::registerApp('app id', 'app secret', 'master secret', 'test secret')
  (重点)
2. 原beecloud.php类BCRESTUtil中的方法request和sdk/src/rest/network.php中代码
  curl_setopt($ch, CURLOPT_FAILONERROR, true)注释掉,以便获取返回http code大于400的结果
  (重点)
3. Test Model,只提供下单和支付订单查询的Sandbox模式,不写setMode函数或者false即live模式,true即test模式
  原在sdk/src/rest/config.php设置TEST_MODE常量,现更改为
  \beecloud\rest\api::setMode(true),
  或者BCRESTApi::setMode(true)
4. 原sdk/src/rest/config.php,更改为在类中定义各常量,以适用于采用composer包管理的用户
5. 修改READMD.md文件